### PR TITLE
Add local multi-workspace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Quillby gives Claude a daily content briefing. It scans articles across your topics, finds what's relevant to your audience, and helps you write posts that sound like you — not generic AI.
 
+Quillby is now workspace-based: use one workspace per Claude Project, client, brand, or campaign.
+
 No extra accounts. No API keys. Everything runs on your computer, inside Claude.
 
 ---
@@ -69,6 +71,12 @@ Claude will ask a few questions about your work, your audience, and what you pub
 
 Once set up, just talk to Claude like normal.
 
+If you work across multiple contexts, start by creating or selecting a workspace:
+
+> "Create a Quillby workspace for my B2B SaaS brand"
+
+> "Switch Quillby to my newsletter workspace"
+
 **Get today's content ideas:**
 
 > "Give me my Quillby daily brief"
@@ -85,7 +93,7 @@ Claude writes it in your voice, based on your profile.
 
 > "Save this draft"
 
-Quillby stores it in the `output/` folder inside your Quillby directory.
+Quillby stores it inside your Quillby data directory, typically `~/.quillby/workspaces/<workspace-id>/output/`.
 
 ---
 
@@ -97,11 +105,17 @@ When Claude writes a post you're happy with, say:
 
 > "Add this post to my Quillby voice examples"
 
-Quillby saves it. Every future post draws on those examples.
+Quillby saves it inside the current workspace. Every future post in that workspace draws on those examples.
 
 To check what Quillby knows about your style:
 
 > "Show me my Quillby voice memory"
+
+You can also save typed editorial memory:
+
+> "Remember this as a Quillby style rule: short paragraphs, no consultant tone"
+
+> "Remember this as a Quillby do-not-say rule: never say 'unlock growth'"
 
 ---
 
@@ -115,7 +129,9 @@ To check what Quillby knows about your style:
 
 **Being specific gets better results.** "Write a 150-word conversational LinkedIn post from idea 2" works much better than "write a post."
 
-**Your content stays on your computer.** Your profile, voice examples, drafts, and content ideas are saved locally in the `output/` folder. Nothing is sent to any external service.
+**Use Claude Projects with Quillby.** Keep structured state in Quillby, and keep long reference material in Claude Project knowledge.
+
+**Your content stays on your computer.** Your profile, memory, drafts, and content ideas are saved locally under `~/.quillby/workspaces/`. Nothing is sent to any external service beyond the AI client you choose to use.
 
 ---
 
@@ -131,7 +147,7 @@ To check what Quillby knows about your style:
 
 ## For developers
 
-HTTP transport, environment variables, scheduled harvest, the full tool reference, and integration configs for VS Code and Cursor: see [docs/MCP.md](docs/MCP.md).
+HTTP transport, environment variables, scheduled harvest, the full tool reference, and integration configs for VS Code and Cursor: see [docs/MCP.md](docs/MCP.md). The implementation roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can also save typed editorial memory:
 
 **Quillby doesn't appear in Claude** — Make sure you fully quit and reopened Claude Desktop after saving the config. Check the path in the config matches exactly what the terminal printed (no extra spaces or missing characters).
 
-**"No context saved" error** — Run the onboarding first: *"Run the quillby_onboarding prompt"*
+**"No context saved" error** — Run onboarding for the current workspace: *"Set me up with Quillby"* or *"Run the quillby_onboarding prompt"*
 
 **"No feeds configured" error** — Ask Claude to find sources: *"Find RSS feeds for my topics and add them to Quillby"*
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -8,7 +8,7 @@ How to connect Quillby to your AI client. Quillby runs locally over stdio — no
 - A built copy of Quillby:
 
 ```bash
-cd /path/to/grist
+cd /path/to/quillby
 npm install
 npm run build
 ```
@@ -24,6 +24,10 @@ npm run build
 | Tool | Parameters | Returns |
 |---|---|---|
 | `quillby_onboard` | *(MCP Elicitation — no params)* | Inline questions → profile saved |
+| `quillby_list_workspaces` | — | Workspace list |
+| `quillby_create_workspace` | `name`, `workspaceId?`, `description?`, `makeCurrent?` | Created workspace |
+| `quillby_select_workspace` | `workspaceId` | Active workspace |
+| `quillby_get_workspace` | `workspaceId?` | Workspace metadata + active state |
 | `quillby_set_context` | `context` object (required) | Confirmation |
 | `quillby_get_context` | — | Profile JSON |
 
@@ -63,14 +67,16 @@ npm run build
 
 | Tool | Parameters | Returns |
 |---|---|---|
-| `quillby_remember` | `post` (string, required) | Confirmation |
+| `quillby_remember` | `entries[]`, `memoryType?` | Confirmation |
+| `quillby_get_memory` | `memoryType?` | Typed memory |
 
 ## Resources
 
 | URI | MIME | Description |
 |---|---|---|
+| `quillby://workspace/current` | `application/json` | Active workspace metadata |
 | `quillby://context` | `application/json` | User content creator profile |
-| `quillby://memory` | `application/json` | Voice examples |
+| `quillby://memory` | `application/json` | Typed memory for the active workspace |
 | `quillby://harvest/latest` | `application/json` | Cards from the latest session |
 | `quillby://feeds` | `text/plain` | Configured RSS feed URLs |
 
@@ -80,6 +86,7 @@ npm run build
 |---|---|
 | `quillby_onboarding` | Guided setup |
 | `quillby_workflow` | Full workflow reference with platform guides |
+| `quillby_projects_playbook` | Claude Projects playbook |
 
 ## Environment
 
@@ -178,7 +185,7 @@ Gemini tooling emphasizes function/tool use. For MCP-capable clients, use the sa
   "mcpServers": {
     "quillby": {
       "type": "stdio",
-      "command": "/absolute/path/to/rss-filter/bin/quillby-mcp",
+      "command": "/absolute/path/to/quillby/bin/quillby-mcp",
       "args": []
     }
   }
@@ -189,8 +196,8 @@ Gemini tooling emphasizes function/tool use. For MCP-capable clients, use the sa
 
 - Quillby suppresses normal CLI stdout while tools execute so MCP JSON-RPC output is not corrupted.
 - `quillby_daily_brief` and `quillby_analyze_articles` require MCP Sampling support in the host client (Claude Desktop supports this).
-- Saved cards and drafts are written to `output/<timestamp>/` and linked from `output/latest`.
-- Voice examples accumulate in `config/memory.json` via `quillby_remember` or `quillby_save_draft` with `addToVoiceExamples: true`.
+- Saved cards and drafts are written under `~/.quillby/workspaces/<workspace-id>/output/<timestamp>/`.
+- Typed memory is written under `~/.quillby/workspaces/<workspace-id>/memory/typed-memory.json`.
 
 ## Practical Recommendation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,177 @@
+# Quillby Roadmap
+
+## Product Direction
+
+Quillby should evolve in clear stages:
+
+1. Published single-workspace local binary
+2. Multi-workspace local binary
+3. Dual-mode architecture for local and hosted runtimes
+4. Hosted remote MCP connector
+5. MCP App and paid hosted tiers
+
+This keeps the product stable while moving from a local-first tool to a more native Claude integration.
+
+## Principles
+
+- One Quillby workspace per Claude Project, client, brand, or campaign.
+- Keep structured editorial state in Quillby workspaces.
+- Keep large background docs in Claude Project knowledge.
+- Preserve local-first operation and backward compatibility.
+- Do not force hosted storage on users who want local-only usage.
+
+## Current State
+
+The current published version is a local MCP binary with one effective workspace.
+
+This branch upgrades Quillby to a local multi-workspace model:
+
+- Dynamic Quillby home via `QUILLBY_HOME`
+- Workspace-scoped storage under `~/.quillby/workspaces/<workspaceId>/`
+- Current-workspace selection
+- Legacy single-profile migration into a `default` workspace
+- Typed memory buckets:
+  - voice examples
+  - style rules
+  - audience insights
+  - do-not-say rules
+  - successful posts
+  - campaign context
+  - source preferences
+- Expanded MCP surface:
+  - `quillby_list_workspaces`
+  - `quillby_create_workspace`
+  - `quillby_select_workspace`
+  - `quillby_get_workspace`
+  - `quillby_get_memory`
+
+## Release Plan
+
+### v0.4: Local Multi-Workspace
+
+Goal: make the workspace model the new stable local foundation.
+
+Scope:
+
+- ship multi-workspace local storage
+- migrate legacy users safely into `default`
+- keep local stdio MCP as the primary distribution
+- update docs and tests around workspace-based usage
+
+Exit criteria:
+
+- migration works without data loss
+- workspace switching is clear in Claude
+- tests pass against isolated local state
+
+### v0.5: Dual-Mode Refactor
+
+Goal: make hosted mode possible without rewriting Quillby.
+
+Scope:
+
+- separate business logic from filesystem layout
+- add service and repository boundaries
+- keep local mode behavior unchanged
+
+Exit criteria:
+
+- local filesystem becomes one storage backend
+- domain logic no longer depends directly on raw file paths
+
+### v0.6: Harden Remote HTTP MCP
+
+Goal: turn HTTP transport into a real deployable MCP server.
+
+Scope:
+
+- production-ready `/mcp` endpoint
+- Streamable HTTP as the canonical remote transport
+- deployment config, health checks, structured logs
+
+Exit criteria:
+
+- Quillby can run as a stable hosted MCP endpoint
+
+### v0.7: Auth Layer
+
+Goal: make hosted Quillby user-scoped and safe.
+
+Scope:
+
+- user accounts or equivalent identity model
+- per-user authentication
+- ideally OAuth-compatible connector auth
+
+Exit criteria:
+
+- each MCP request maps to an authenticated user
+- no shared global hosted state
+
+### v0.8: Hosted Persistence
+
+Goal: move hosted state off the local filesystem.
+
+Scope:
+
+- database-backed hosted storage for:
+  - workspaces
+  - context
+  - typed memory
+  - sources
+  - harvests
+  - cards
+  - drafts
+- keep filesystem storage for local mode
+
+Exit criteria:
+
+- local mode uses filesystem storage
+- hosted mode uses user-scoped backend storage
+- both run on the same domain model
+
+### v0.9: Claude Connector Readiness
+
+Goal: make Quillby feel coherent as a remote connector.
+
+Scope:
+
+- narrow and polish the tool surface
+- improve read/write tool metadata
+- write custom connector setup docs
+- test through Claude custom connector flows
+
+Exit criteria:
+
+- Quillby can be added as a custom remote connector
+- workspace selection is clear in Claude
+
+### v1.0: Hosted Quillby
+
+Goal: release the first supported hosted Quillby connector.
+
+Scope:
+
+- stable hosted MCP service
+- local mode still supported
+- explicit local-to-hosted migration or import path
+
+### v1.1+: MCP App And Paid Tiers
+
+Goal: improve the native experience and productize hosted Quillby.
+
+Scope:
+
+- MCP App for shortlist review, filters, approvals, and workspace switching
+- hosted plans and billing
+- optional team/shared use cases
+
+## Near-Term Follow-Ups
+
+After local multi-workspace lands, the next local hardening steps should be:
+
+1. Add per-tool workspace overrides so Claude can operate across workspaces without changing the global selection.
+2. Add explicit schema versions and migrations.
+3. Add atomic writes and file locking around workspace state.
+4. Add richer memory entries with timestamps, tags, and provenance.
+5. Add source trust, freshness, and duplicate clustering metadata.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vncsleal/quillby",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vncsleal/quillby",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vncsleal/quillby",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Quillby — AI copywriting assistant. Reads the internet and writes content in your voice.",
   "license": "MIT",
   "author": "Vinicius Leal",

--- a/src/agents/discover.ts
+++ b/src/agents/discover.ts
@@ -1,14 +1,13 @@
 import * as fs from "fs";
-import { CONFIG, readTextFile } from "../config.js";
-
-const SOURCES_FILE = CONFIG.FILES.SOURCES;
+import { ensureDir, readTextFile } from "../config.js";
+import { getCurrentWorkspaceId, getWorkspacePaths, touchWorkspace } from "../workspaces.js";
 
 /**
  * Load current RSS sources from file. Returns empty array if file missing.
  */
 export function loadSources(): string[] {
   try {
-    return readTextFile(CONFIG.FILES.SOURCES)
+    return readTextFile(getWorkspacePaths(getCurrentWorkspaceId()).sources)
       .split("\n")
       .map((s) => s.trim())
       .filter((s) => s && !s.startsWith("#"));
@@ -21,16 +20,19 @@ export function loadSources(): string[] {
  * Append new feed URLs to the sources file, deduplicating against existing entries.
  */
 export function appendSources(newUrls: string[]): { added: number; skipped: number } {
+  const sourcesFile = getWorkspacePaths(getCurrentWorkspaceId()).sources;
   const existing = new Set(loadSources());
   const toAdd = newUrls.filter((u) => u.trim() && !existing.has(u.trim()));
 
   if (toAdd.length === 0) return { added: 0, skipped: newUrls.length };
 
-  const header = !fs.existsSync(SOURCES_FILE)
+  ensureDir(getWorkspacePaths(getCurrentWorkspaceId()).root);
+  const header = !fs.existsSync(sourcesFile)
     ? "# Quillby RSS Sources\n\n"
     : "";
 
-  fs.appendFileSync(SOURCES_FILE, header + toAdd.join("\n") + "\n");
+  fs.appendFileSync(sourcesFile, header + toAdd.join("\n") + "\n");
+  touchWorkspace(getCurrentWorkspaceId());
 
   return { added: toAdd.length, skipped: newUrls.length - toAdd.length };
 }
@@ -39,7 +41,9 @@ export function appendSources(newUrls: string[]): { added: number; skipped: numb
  * Replace the entire sources file with a new list.
  */
 export function replaceSources(urls: string[]): void {
+  const sourcesFile = getWorkspacePaths(getCurrentWorkspaceId()).sources;
   const unique = [...new Set(urls.map((u) => u.trim()).filter(Boolean))];
-  fs.writeFileSync(SOURCES_FILE, "# Quillby RSS Sources\n\n" + unique.join("\n") + "\n");
+  ensureDir(getWorkspacePaths(getCurrentWorkspaceId()).root);
+  fs.writeFileSync(sourcesFile, "# Quillby RSS Sources\n\n" + unique.join("\n") + "\n");
+  touchWorkspace(getCurrentWorkspaceId());
 }
-

--- a/src/agents/onboard.ts
+++ b/src/agents/onboard.ts
@@ -1,61 +1,64 @@
 import * as fs from "fs";
-import * as path from "path";
-import { CONFIG, ensureDir } from "../config.js";
-import { UserContextSchema, type UserContext, UserMemorySchema, type UserMemory } from "../types.js";
-
-const CONTEXT_FILE = CONFIG.FILES.CONTEXT;
-const MEMORY_FILE = CONFIG.FILES.MEMORY;
+import {
+  appendTypedMemory,
+  getCurrentWorkspaceId,
+  getCurrentWorkspace,
+  getWorkspacePaths,
+  loadTypedMemory,
+  loadWorkspaceContext,
+  saveTypedMemory,
+  saveWorkspaceContext,
+} from "../workspaces.js";
+import {
+  UserContextSchema,
+  type UserContext,
+  UserMemorySchema,
+  type UserMemory,
+  type TypedMemory,
+} from "../types.js";
 
 export function contextExists(): boolean {
-  return fs.existsSync(CONTEXT_FILE);
+  return fs.existsSync(getWorkspacePaths(getCurrentWorkspaceId()).context);
 }
 
 export function loadContext(): UserContext | null {
-  if (!fs.existsSync(CONTEXT_FILE)) return null;
-  try {
-    const raw = JSON.parse(fs.readFileSync(CONTEXT_FILE, "utf-8"));
-    return UserContextSchema.parse(raw);
-  } catch {
-    return null;
-  }
+  return loadWorkspaceContext(getCurrentWorkspaceId());
 }
 
 export function saveContext(ctx: UserContext): void {
-  ensureDir(path.dirname(CONTEXT_FILE));
-  const validated = UserContextSchema.parse(ctx);
-  fs.writeFileSync(CONTEXT_FILE, JSON.stringify(validated, null, 2));
+  saveWorkspaceContext(getCurrentWorkspaceId(), UserContextSchema.parse(ctx));
 }
 
 export function memoryExists(): boolean {
-  return fs.existsSync(MEMORY_FILE);
+  return fs.existsSync(getWorkspacePaths(getCurrentWorkspaceId()).typedMemory);
 }
 
 export function loadMemory(): UserMemory {
-  if (!fs.existsSync(MEMORY_FILE)) return UserMemorySchema.parse({});
-  try {
-    const raw = JSON.parse(fs.readFileSync(MEMORY_FILE, "utf-8"));
-    return UserMemorySchema.parse(raw);
-  } catch {
-    return UserMemorySchema.parse({});
-  }
+  const typed = loadTypedMemory(getCurrentWorkspaceId());
+  return UserMemorySchema.parse({ voiceExamples: typed.voiceExamples });
 }
 
 export function saveMemory(mem: UserMemory): void {
-  ensureDir(path.dirname(MEMORY_FILE));
-  fs.writeFileSync(MEMORY_FILE, JSON.stringify(UserMemorySchema.parse(mem), null, 2));
+  const validated = UserMemorySchema.parse(mem);
+  saveTypedMemory(getCurrentWorkspaceId(), {
+    voiceExamples: validated.voiceExamples.slice(0, 10),
+  });
 }
 
 export function appendVoiceExample(text: string): void {
-  const mem = loadMemory();
-  const examples = [text, ...mem.voiceExamples].slice(0, 10);
-  saveMemory({ ...mem, voiceExamples: examples });
+  appendTypedMemory(getCurrentWorkspaceId(), "voiceExamples", [text], 10);
+}
+
+export function loadTypedWorkspaceMemory(): TypedMemory {
+  return loadTypedMemory(getCurrentWorkspaceId());
 }
 
 /**
  * Render the user context as a concise text block for LLM system prompts.
  */
-export function contextToPromptText(ctx: UserContext, memory?: UserMemory): string {
+export function contextToPromptText(ctx: UserContext, memory?: UserMemory, typedMemory?: TypedMemory): string {
   const lines = [
+    `Workspace: ${getCurrentWorkspace().name}`,
     ctx.name ? `Name: ${ctx.name}` : null,
     `Role: ${ctx.role}`,
     `Industry: ${ctx.industry}`,
@@ -74,7 +77,17 @@ export function contextToPromptText(ctx: UserContext, memory?: UserMemory): stri
       ? `\n\nVoice examples:\n${memory.voiceExamples.map((e, i) => `[${i + 1}] ${e}`).join("\n\n")}`
       : "";
 
-  return lines + examples;
+  const typedBlocks = typedMemory
+    ? [
+        typedMemory.styleRules.length ? `\n\nStyle rules:\n${typedMemory.styleRules.map((e, i) => `[${i + 1}] ${e}`).join("\n")}` : "",
+        typedMemory.audienceInsights.length ? `\n\nAudience insights:\n${typedMemory.audienceInsights.map((e, i) => `[${i + 1}] ${e}`).join("\n")}` : "",
+        typedMemory.doNotSay.length ? `\n\nDo not say:\n${typedMemory.doNotSay.map((e, i) => `[${i + 1}] ${e}`).join("\n")}` : "",
+        typedMemory.campaignContext.length ? `\n\nCampaign context:\n${typedMemory.campaignContext.map((e, i) => `[${i + 1}] ${e}`).join("\n")}` : "",
+        typedMemory.sourcePreferences.length ? `\n\nSource preferences:\n${typedMemory.sourcePreferences.map((e, i) => `[${i + 1}] ${e}`).join("\n")}` : "",
+      ].join("")
+    : "";
+
+  return lines + examples + typedBlocks;
 }
 
 /** The onboarding prompt text — used as an MCP prompt. */

--- a/src/agents/onboard.ts
+++ b/src/agents/onboard.ts
@@ -91,7 +91,7 @@ export function contextToPromptText(ctx: UserContext, memory?: UserMemory, typed
 }
 
 /** The onboarding prompt text — used as an MCP prompt. */
-export const ONBOARDING_PROMPT = `You are helping a new Quillby user set up their content intelligence profile.
+export const ONBOARDING_PROMPT = `You are helping a new Quillby user set up the content intelligence profile for their current Quillby workspace.
 
 Ask the following questions conversationally — you don't need to number them or ask them all at once. Use natural follow-up based on their answers.
 
@@ -104,6 +104,6 @@ Questions to cover:
 6. What are your content goals? (e.g., thought leadership, personal brand, lead generation, community building)
 7. Are there any topics you want to avoid in your content?
 8. Which platforms do you publish on? (LinkedIn, X/Twitter, blog, newsletter, Medium, etc.)
-Once you have their answers, call the \`quillby_set_context\` tool with the structured data. After saving, let them know their profile is ready and suggest:
+Once you have their answers, call the \`quillby_set_context\` tool with the structured data for the current workspace. After saving, let them know the workspace profile is ready and suggest:
 - Running \`quillby_add_feeds\` to add relevant RSS sources.
-- Using \`quillby_remember\` to add example posts that define their voice — these accumulate in memory and improve every post Quillby generates.`;
+- Using \`quillby_remember\` to add example posts that define their voice — these accumulate in workspace memory and improve every post Quillby generates there.`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,15 +2,34 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 
-const DATA_DIR = path.join(os.homedir(), ".quillby");
+const DEFAULT_DATA_DIR = path.join(os.homedir(), ".quillby");
 
 export const CONFIG = {
+  get DATA_DIR() {
+    return process.env.QUILLBY_HOME?.trim() || DEFAULT_DATA_DIR;
+  },
   FILES: {
-    CONTEXT: path.join(DATA_DIR, "context.json"),
-    MEMORY: path.join(DATA_DIR, "memory.json"),
-    SOURCES: path.join(DATA_DIR, "rss_sources.txt"),
-    OUTPUT_DIR: path.join(DATA_DIR, "output"),
-    CACHE: path.join(DATA_DIR, ".cache/seen_urls.json"),
+    get CONTEXT() {
+      return path.join(CONFIG.DATA_DIR, "context.json");
+    },
+    get MEMORY() {
+      return path.join(CONFIG.DATA_DIR, "memory.json");
+    },
+    get SOURCES() {
+      return path.join(CONFIG.DATA_DIR, "rss_sources.txt");
+    },
+    get OUTPUT_DIR() {
+      return path.join(CONFIG.DATA_DIR, "output");
+    },
+    get CACHE() {
+      return path.join(CONFIG.DATA_DIR, ".cache/seen_urls.json");
+    },
+    get WORKSPACES_DIR() {
+      return path.join(CONFIG.DATA_DIR, "workspaces");
+    },
+    get CURRENT_WORKSPACE() {
+      return path.join(CONFIG.DATA_DIR, "current_workspace.txt");
+    },
   },
   RSS: {
     ITEMS_PER_FEED: parseInt(process.env.RSS_ITEMS_PER_FEED || "5", 10),
@@ -29,6 +48,11 @@ export function ensureDir(dir: string) {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 }
 
+export function ensureDataDir() {
+  ensureDir(CONFIG.DATA_DIR);
+  ensureDir(CONFIG.FILES.WORKSPACES_DIR);
+}
+
 export function readTextFile(filePath: string): string {
   const ext = path.extname(filePath);
   const localVariant = ext
@@ -44,8 +68,3 @@ export function readTextFile(filePath: string): string {
 
   throw new Error(`Cannot read config file: ${filePath}`);
 }
-
-// Initialize required directories on import
-ensureDir(path.dirname(CONFIG.FILES.CACHE));
-ensureDir(CONFIG.FILES.OUTPUT_DIR);
-

--- a/src/extractors/rss.ts
+++ b/src/extractors/rss.ts
@@ -2,19 +2,20 @@ import * as fs from "fs";
 import Parser from "rss-parser";
 import { CONFIG } from "../config.js";
 import type { RssItem } from "../types.js";
+import { getCurrentWorkspaceId, getWorkspacePaths } from "../workspaces.js";
 
 const parser = new Parser({
   timeout: CONFIG.RSS.TIMEOUT,
-  requestOptions: { rejectUnauthorized: false },
   headers: {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
   },
 });
 
 export function getSeenUrls(): Set<string> {
+  const cacheFile = getWorkspacePaths(getCurrentWorkspaceId()).cache;
   try {
-    if (fs.existsSync(CONFIG.FILES.CACHE)) {
-      return new Set(JSON.parse(fs.readFileSync(CONFIG.FILES.CACHE, "utf-8")) as string[]);
+    if (fs.existsSync(cacheFile)) {
+      return new Set(JSON.parse(fs.readFileSync(cacheFile, "utf-8")) as string[]);
     }
   } catch {
     // Ignore malformed cache.
@@ -23,7 +24,9 @@ export function getSeenUrls(): Set<string> {
 }
 
 export function saveSeenUrls(urls: Set<string>) {
-  fs.writeFileSync(CONFIG.FILES.CACHE, JSON.stringify([...urls], null, 2));
+  const cacheFile = getWorkspacePaths(getCurrentWorkspaceId()).cache;
+  fs.mkdirSync(getWorkspacePaths(getCurrentWorkspaceId()).cacheDir, { recursive: true });
+  fs.writeFileSync(cacheFile, JSON.stringify([...urls], null, 2));
 }
 
 export async function fetchFeeds(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,6 +24,7 @@ import {
   ONBOARDING_PROMPT,
   loadMemory,
   appendVoiceExample,
+  loadTypedWorkspaceMemory,
 } from "../agents/onboard.js";
 import { loadSources, appendSources } from "../agents/discover.js";
 import { fetchArticles, preScoreArticles } from "../agents/harvest.js";
@@ -37,6 +38,27 @@ import {
   saveHarvestOutput,
   saveDraft,
 } from "../output/structures.js";
+import {
+  appendTypedMemory,
+  createWorkspace,
+  getCurrentWorkspace,
+  getCurrentWorkspaceId,
+  listWorkspaces,
+  loadWorkspace,
+  setCurrentWorkspace,
+} from "../workspaces.js";
+
+const MEMORY_TYPES = {
+  voice_examples: "voiceExamples",
+  style_rules: "styleRules",
+  audience_insights: "audienceInsights",
+  do_not_say: "doNotSay",
+  successful_posts: "successfulPosts",
+  campaign_context: "campaignContext",
+  source_preferences: "sourcePreferences",
+} as const;
+
+type MemoryTypeInput = keyof typeof MEMORY_TYPES;
 
 const server = new Server(
   { name: "quillby-mcp", version: "0.3.4" },
@@ -78,6 +100,54 @@ const TOOLS: Tool[] = [
   },
 
   // ── Profile ───────────────────────────────────────────────────────────────
+  {
+    name: "quillby_list_workspaces",
+    description: "List Quillby workspaces. Use one workspace per Claude Project, client, publication, or campaign.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "quillby_create_workspace",
+    description: "Create a workspace with isolated context, memories, feeds, and outputs.",
+    annotations: { destructiveHint: false },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        workspaceId: { type: "string" },
+        description: { type: "string" },
+        makeCurrent: { type: "boolean" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "quillby_select_workspace",
+    description: "Switch the active Quillby workspace.",
+    annotations: { destructiveHint: false, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspaceId: { type: "string" },
+      },
+      required: ["workspaceId"],
+    },
+  },
+  {
+    name: "quillby_get_workspace",
+    description: "Inspect the active workspace or a specific workspace.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspaceId: { type: "string" },
+      },
+    },
+  },
   {
     name: "quillby_set_context",
     description: "Save the user content creator profile after onboarding.",
@@ -332,24 +402,50 @@ const TOOLS: Tool[] = [
   {
     name: "quillby_remember",
     description:
-      "Add one or more approved posts to your voice memory. These accumulate in memory.json and are used to guide voice in every post Quillby generates. Up to 10 most recent examples are kept.",
+      "Add structured memory to the current workspace. Supports voice examples plus typed editorial memory buckets.",
     annotations: { destructiveHint: false },
     outputSchema: { type: "object" as const },
     inputSchema: {
       type: "object",
       properties: {
-        voiceExamples: {
+        entries: {
           type: "array",
           items: { type: "string" },
-          description: "Post text(s) to add as voice examples.",
+          description: "Memory entries to add.",
+        },
+        memoryType: {
+          type: "string",
+          enum: Object.keys(MEMORY_TYPES),
+          description: "voice_examples, style_rules, audience_insights, do_not_say, successful_posts, campaign_context, source_preferences",
         },
       },
-      required: ["voiceExamples"],
+      required: ["entries"],
+    },
+  },
+  {
+    name: "quillby_get_memory",
+    description: "Read typed memory from the current workspace.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        memoryType: {
+          type: "string",
+          enum: Object.keys(MEMORY_TYPES),
+        },
+      },
     },
   },
 ];
 
 const RESOURCES: Resource[] = [
+  {
+    uri: "quillby://workspace/current",
+    name: "Active Workspace",
+    description: "Current Quillby workspace metadata.",
+    mimeType: "application/json",
+  },
   {
     uri: "quillby://context",
     name: "User Content Profile",
@@ -359,7 +455,7 @@ const RESOURCES: Resource[] = [
   {
     uri: "quillby://memory",
     name: "User Memory",
-    description: "Accumulated voice examples and other memory that grows over sessions.",
+    description: "Typed memory for the active workspace.",
     mimeType: "application/json",
   },
   {
@@ -385,6 +481,10 @@ const PROMPTS: Prompt[] = [
     name: "quillby_workflow",
     description: "Full Quillby workflow: onboard, discover feeds, fetch, analyze, generate posts.",
   },
+  {
+    name: "quillby_projects_playbook",
+    description: "How to align Quillby workspaces with Claude Projects.",
+  },
 ];
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
@@ -394,6 +494,74 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
   try {
     switch (name) {
+      case "quillby_list_workspaces": {
+        const currentWorkspaceId = getCurrentWorkspaceId();
+        const workspaces = listWorkspaces().map((workspace) => ({
+          ...workspace,
+          current: workspace.id === currentWorkspaceId,
+        }));
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ currentWorkspaceId, workspaces }, null, 2) }],
+          structuredContent: { currentWorkspaceId, workspaces },
+        };
+      }
+
+      case "quillby_create_workspace": {
+        const { name: workspaceName, workspaceId, description, makeCurrent } = args as {
+          name: string;
+          workspaceId?: string;
+          description?: string;
+          makeCurrent?: boolean;
+        };
+        const workspace = createWorkspace({
+          id: workspaceId,
+          name: workspaceName,
+          description,
+          makeCurrent: makeCurrent ?? true,
+        });
+        return {
+          content: [{ type: "text" as const, text: `Workspace "${workspace.name}" created with id "${workspace.id}".` }],
+          structuredContent: workspace,
+        };
+      }
+
+      case "quillby_select_workspace": {
+        const { workspaceId } = args as { workspaceId: string };
+        const workspace = setCurrentWorkspace(workspaceId);
+        return {
+          content: [{ type: "text" as const, text: `Current workspace set to "${workspace.name}" (${workspace.id}).` }],
+          structuredContent: workspace,
+        };
+      }
+
+      case "quillby_get_workspace": {
+        const workspaceId = (args as { workspaceId?: string }).workspaceId ?? getCurrentWorkspaceId();
+        const workspace = loadWorkspace(workspaceId);
+        if (!workspace) {
+          return { content: [{ type: "text" as const, text: `Workspace "${workspaceId}" not found.` }], structuredContent: { error: "not_found", workspaceId } };
+        }
+        const isCurrent = workspace.id === getCurrentWorkspaceId();
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              workspace,
+              current: isCurrent,
+              context: isCurrent ? loadContext() : null,
+              memory: isCurrent ? loadTypedWorkspaceMemory() : null,
+              feedCount: isCurrent ? loadSources().length : null,
+            }, null, 2),
+          }],
+          structuredContent: {
+            workspace,
+            current: isCurrent,
+            context: isCurrent ? loadContext() : null,
+            memory: isCurrent ? loadTypedWorkspaceMemory() : null,
+            feedCount: isCurrent ? loadSources().length : null,
+          },
+        };
+      }
+
       case "quillby_onboard": {
         const caps = server.getClientCapabilities();
         if (!caps?.elicitation?.form) {
@@ -487,7 +655,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         });
         saveContext(onboardCtx);
 
-        const summary = `Profile saved!\n\nRole: ${onboardCtx.role} in ${onboardCtx.industry}\nTopics: ${onboardCtx.topics.join(", ")}\nPlatforms: ${onboardCtx.platforms.join(", ")}\nVoice: ${onboardCtx.voice}\n\nNext: call quillby_discover_feeds to set up your RSS sources.`;
+        const summary = `Workspace: ${getCurrentWorkspace().name}\n\nRole: ${onboardCtx.role} in ${onboardCtx.industry}\nTopics: ${onboardCtx.topics.join(", ")}\nPlatforms: ${onboardCtx.platforms.join(", ")}\nVoice: ${onboardCtx.voice}\n\nNext: call quillby_discover_feeds to set up your RSS sources.`;
         return {
           content: [{ type: "text" as const, text: summary }],
           structuredContent: { saved: true, profile: onboardCtx as unknown as Record<string, unknown> },
@@ -498,8 +666,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         const context = UserContextSchema.parse((args as { context: unknown }).context);
         saveContext(context);
         return {
-          content: [{ type: "text" as const, text: `Context saved. Role: ${context.role}. Topics: ${context.topics.join(", ")}. Platforms: ${context.platforms.join(", ")}.` }],
-          structuredContent: { saved: true, role: context.role, topics: context.topics, platforms: context.platforms },
+          content: [{ type: "text" as const, text: `Context saved for workspace "${getCurrentWorkspace().name}". Role: ${context.role}. Topics: ${context.topics.join(", ")}. Platforms: ${context.platforms.join(", ")}.` }],
+          structuredContent: { saved: true, workspaceId: getCurrentWorkspaceId(), role: context.role, topics: context.topics, platforms: context.platforms },
         };
       }
 
@@ -508,7 +676,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           return { content: [{ type: "text" as const, text: "No context saved. Run quillby_onboarding first." }], structuredContent: { error: "no_context" } };
         }
         const ctxData = loadContext()!;
-        return { content: [{ type: "text" as const, text: JSON.stringify(ctxData, null, 2) }], structuredContent: ctxData as unknown as Record<string, unknown> };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ workspace: getCurrentWorkspace(), context: ctxData }, null, 2) }],
+          structuredContent: { workspace: getCurrentWorkspace(), context: ctxData },
+        };
       }
 
       case "quillby_add_feeds": {
@@ -719,15 +890,15 @@ Return ONLY a JSON array of integers — the indices of the top ${topN} most rel
         const articleBlobs = enriched.map((a, i) =>
           `## Article ${i + 1}: ${a.title}\nURL: ${a.url}\n\n${a.content ?? a.snippet}`
         ).join("\n\n---\n\n");
-        const voiceBlock = loadMemory().voiceExamples.length
-          ? `\n\nUser voice examples (study and match this style — do NOT smooth it out):\n${loadMemory().voiceExamples.map((e, i) => `[${i + 1}]\n${e}`).join("\n\n")}`
+        const memory = loadMemory();
+        const typedMemory = loadTypedWorkspaceMemory();
+        const voiceBlock = memory.voiceExamples.length
+          ? `\n\nUser voice examples (study and match this style — do NOT smooth it out):\n${memory.voiceExamples.map((e, i) => `[${i + 1}]\n${e}`).join("\n\n")}`
           : `\n\nUser voice: ${ctx.voice ?? "direct and authentic"}`;
 
         const analysisPrompt = `You are an expert content strategist. Analyze these articles for a ${ctx.role} in ${ctx.industry ?? "their industry"}.
 
-User topics: ${ctx.topics.join(", ")}
-User audience: ${ctx.audienceDescription ?? "general"}
-User platforms: ${ctx.platforms.join(", ")}${voiceBlock}
+${contextToPromptText(ctx, memory, typedMemory)}${voiceBlock}
 
 ${articleBlobs}
 
@@ -848,8 +1019,10 @@ Return ONLY a JSON array of integers — the indices of the top ${topN} most rel
 
         // Pass 3: Sampling generates full cards in one call
         log("Generating content cards via Sampling...");
-        const voiceBlock3 = loadMemory().voiceExamples.length
-          ? `\n\nVoice examples — match this style, amplify the strongest quirks:\n${loadMemory().voiceExamples.map((e, i) => `[${i + 1}]\n${e}`).join("\n\n")}`
+        const memory3 = loadMemory();
+        const typedMemory3 = loadTypedWorkspaceMemory();
+        const voiceBlock3 = memory3.voiceExamples.length
+          ? `\n\nVoice examples — match this style, amplify the strongest quirks:\n${memory3.voiceExamples.map((e, i) => `[${i + 1}]\n${e}`).join("\n\n")}`
           : `\n\nVoice: ${ctx.voice ?? "direct and authentic"}`;
         const articleBlobs = enriched
           .map((a, i) => `## Article ${i + 1}: ${a.title}\nURL: ${a.link}\n\n${a.content ?? a.snippet}`)
@@ -858,8 +1031,7 @@ Return ONLY a JSON array of integers — the indices of the top ${topN} most rel
           ctx.industry ?? "their industry"
         }.
 
-User topics: ${ctx.topics.join(", ")}
-User platforms: ${ctx.platforms.join(", ")}${voiceBlock3}
+${contextToPromptText(ctx, memory3, typedMemory3)}${voiceBlock3}
 
 ${articleBlobs}
 
@@ -959,13 +1131,15 @@ Return ONLY a valid JSON array of these objects, no prose.`;
           return { content: [{ type: "text" as const, text: `Card #${genCardId} not found. Available: ${genBundle.cards.map((c) => c.id).join(", ")}.` }], structuredContent: { error: "not_found", cardId: genCardId } };
         }
         const genCtx = loadContext()!;
+        const currentMemory = loadMemory();
+        const typedMemory = loadTypedWorkspaceMemory();
         const guide = PLATFORM_GUIDES[genPlatform];
         if (!guide) {
           return { content: [{ type: "text" as const, text: `Unknown platform: "${genPlatform}". Available: ${Object.keys(PLATFORM_GUIDES).join(", ")}.` }], structuredContent: { error: "unknown_platform", platform: genPlatform } };
         }
         const chosenAngle = angle ?? genCard.angleOptions?.[0] ?? genCard.thesis;
-        const genVoiceBlock = loadMemory().voiceExamples.length
-          ? `Voice examples — read these carefully. Match the register, rhythm, and vocabulary exactly. Oversteer on the strongest quirks:\n${loadMemory().voiceExamples.map((e, i) => `[${i + 1}]\n${e}`).join("\n\n")}`
+        const genVoiceBlock = currentMemory.voiceExamples.length
+          ? `Voice examples — read these carefully. Match the register, rhythm, and vocabulary exactly. Oversteer on the strongest quirks:\n${currentMemory.voiceExamples.map((e, i) => `[${i + 1}]\n${e}`).join("\n\n")}`
           : `Voice description: ${genCtx.voice ?? "direct and authentic"}`;
         const genAnglesHint = "";
         const generatePrompt = `You are writing a ${genPlatform} post for ${
@@ -973,9 +1147,10 @@ Return ONLY a valid JSON array of these objects, no prose.`;
         } — a ${genCtx.role} in ${genCtx.industry ?? "their industry"}.
 
 ## User profile
-- Audience: ${genCtx.audienceDescription ?? "general"}
-- Goals: ${genCtx.contentGoals.join(", ")}
-- Platforms: ${genCtx.platforms.join(", ")}
+${contextToPromptText(genCtx, currentMemory, typedMemory)
+  .split("\n")
+  .map((line) => `- ${line}`)
+  .join("\n")}
 
 ## ${genVoiceBlock}
 
@@ -1013,11 +1188,36 @@ ${guide}${genAnglesHint}
       }
 
       case "quillby_remember": {
-        const { voiceExamples: newExamples } = args as { voiceExamples: string[] };
-        for (const ex of newExamples) appendVoiceExample(ex);
+        const { entries, memoryType = "voice_examples" } = args as {
+          entries: string[];
+          memoryType?: MemoryTypeInput;
+        };
+        const resolvedType = MEMORY_TYPES[memoryType];
+        appendTypedMemory(
+          getCurrentWorkspaceId(),
+          resolvedType,
+          entries,
+          resolvedType === "voiceExamples" ? 10 : undefined
+        );
         return {
-          content: [{ type: "text" as const, text: `Added ${newExamples.length} voice example(s) to memory.` }],
-          structuredContent: { added: newExamples.length },
+          content: [{ type: "text" as const, text: `Added ${entries.length} item(s) to ${memoryType} in workspace "${getCurrentWorkspace().name}".` }],
+          structuredContent: { added: entries.length, memoryType, workspaceId: getCurrentWorkspaceId() },
+        };
+      }
+
+      case "quillby_get_memory": {
+        const { memoryType } = args as { memoryType?: MemoryTypeInput };
+        const typedMemory = loadTypedWorkspaceMemory();
+        if (!memoryType) {
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ workspace: getCurrentWorkspace(), memory: typedMemory }, null, 2) }],
+            structuredContent: { workspace: getCurrentWorkspace(), memory: typedMemory },
+          };
+        }
+        const resolvedType = MEMORY_TYPES[memoryType];
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ workspace: getCurrentWorkspace(), memoryType, entries: typedMemory[resolvedType] }, null, 2) }],
+          structuredContent: { workspace: getCurrentWorkspace(), memoryType, entries: typedMemory[resolvedType] },
         };
       }
 
@@ -1035,6 +1235,10 @@ server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: R
 server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
   const { uri } = req.params;
   switch (uri) {
+    case "quillby://workspace/current": {
+      const text = JSON.stringify(getCurrentWorkspace(), null, 2);
+      return { contents: [{ uri, mimeType: "application/json", text }] };
+    }
     case "quillby://context": {
       const text = contextExists()
         ? JSON.stringify(loadContext(), null, 2)
@@ -1042,7 +1246,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
       return { contents: [{ uri, mimeType: "application/json", text }] };
     }
     case "quillby://memory": {
-      const text = JSON.stringify(loadMemory(), null, 2);
+      const text = JSON.stringify(loadTypedWorkspaceMemory(), null, 2);
       return { contents: [{ uri, mimeType: "application/json", text }] };
     }
     case "quillby://harvest/latest": {
@@ -1068,6 +1272,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (req) => {
     case "quillby_onboarding": {
       const exists = contextExists();
       const existing = exists ? loadContext() : null;
+      const typedMemory = loadTypedWorkspaceMemory();
       return {
         description: "Quillby onboarding",
         messages: [
@@ -1076,7 +1281,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (req) => {
             content: {
               type: "text" as const,
               text: exists
-                ? `I have a saved profile:\n\n${contextToPromptText(existing!, loadMemory())}\n\nUpdate it?`
+                ? `I have a saved profile in workspace "${getCurrentWorkspace().name}":\n\n${contextToPromptText(existing!, loadMemory(), typedMemory)}\n\nUpdate it?`
                 : "Set up Quillby for my content workflow.",
             },
           },
@@ -1100,6 +1305,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (req) => {
 
       const ctx = contextExists() ? loadContext() : null;
       const mem = loadMemory();
+      const typed = loadTypedWorkspaceMemory();
       const voiceSection = mem.voiceExamples.length
         ? `### Voice reference (read before writing any draft)
 
@@ -1112,11 +1318,14 @@ ${mem.voiceExamples.map((e, i) => `**Example ${i + 1}:**\n\`\`\`\n${e}\n\`\`\``)
 
       const workflowText = `## Quillby Workflow
 
+Workspace: ${getCurrentWorkspace().name} (${getCurrentWorkspaceId()})
+
 Quillby handles file I/O and data plumbing. All editorial judgment lives in the model.
 
 ### Setup (once)
-1. Run quillby_onboarding prompt, collect answers, call quillby_set_context.
-2. Call quillby_discover_feeds — it matches your topics against a curated seed list and optionally expands it via Sampling. No manual feed hunting needed.
+1. If you are working across clients, brands, or campaigns, call quillby_create_workspace first.
+2. Run quillby_onboarding prompt, collect answers, call quillby_set_context.
+3. Call quillby_discover_feeds — it matches your topics against a curated seed list and optionally expands it via Sampling. No manual feed hunting needed.
 
 ### Daily workflow — Automated (when Sampling is available)
 1. Call quillby_analyze_articles (limit: 8–12). Quillby fetches articles, pre-scores by topic overlap, enriches the top N, sends them to you via Sampling, and saves the resulting cards automatically.
@@ -1137,10 +1346,16 @@ Quillby handles file I/O and data plumbing. All editorial judgment lives in the 
 
 ### Voice rules (apply before writing any draft)
 - Read the user's voice examples from quillby://memory. Identify the 2-3 strongest stylistic quirks. Amplify them — oversteer, not understeer.
+- Use typed memory buckets: style_rules, do_not_say, audience_insights, campaign_context.
 - BANNED: “It’s not X, it’s Y” contrasts. Em-dash clusters. Bullet lists as prose. “Game-changer”, “transformative”, “powerful”, “unlock”, “leverage”, “dive into”. Filler openers (“In today’s world”, “Here’s the thing”). Emoji stacking. Numbered listicles. Motivational closings.
 - Write like the user, not like an assistant helping the user.
 
 ${voiceSection}
+
+### Typed memory snapshot
+\`\`\`json
+${JSON.stringify(typed, null, 2)}
+\`\`\`
 
 ### Platform guides
 
@@ -1151,6 +1366,28 @@ ${platformGuideText}`;
         messages: [
           { role: "user" as const, content: { type: "text" as const, text: "How do I use Quillby?" } },
           { role: "assistant" as const, content: { type: "text" as const, text: workflowText } },
+        ],
+      };
+    }
+
+    case "quillby_projects_playbook": {
+      const playbook = `## Quillby + Claude Projects
+
+1. Create one Quillby workspace per Claude Project, client, brand, or campaign.
+2. Keep structured profile, feeds, typed memory, harvests, and drafts in Quillby.
+3. Keep long background documents inside Claude Project knowledge.
+4. Use memory buckets deliberately:
+   - voice_examples for approved writing samples
+   - style_rules for positive editorial constraints
+   - do_not_say for banned phrasing
+   - audience_insights for what readers care about
+   - campaign_context for temporary initiative-specific context
+   - source_preferences for preferred publications or communities`;
+      return {
+        description: "Quillby Projects playbook",
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: "How should I use Quillby with Claude Projects?" } },
+          { role: "assistant" as const, content: { type: "text" as const, text: playbook } },
         ],
       };
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -61,7 +61,7 @@ const MEMORY_TYPES = {
 type MemoryTypeInput = keyof typeof MEMORY_TYPES;
 
 const server = new Server(
-  { name: "quillby-mcp", version: "0.3.4" },
+  { name: "quillby-mcp", version: "0.4.0" },
   { capabilities: { tools: {}, resources: {}, prompts: {}, logging: {} } }
 );
 
@@ -1345,7 +1345,7 @@ Quillby handles file I/O and data plumbing. All editorial judgment lives in the 
 8. Call quillby_save_draft to persist it.
 
 ### Voice rules (apply before writing any draft)
-- Read the user's voice examples from quillby://memory. Identify the 2-3 strongest stylistic quirks. Amplify them — oversteer, not understeer.
+- Read the active workspace memory from quillby://memory. Focus first on voice_examples, then apply style_rules, do_not_say, audience_insights, and campaign_context. Identify the 2-3 strongest stylistic quirks and amplify them — oversteer, not understeer.
 - Use typed memory buckets: style_rules, do_not_say, audience_insights, campaign_context.
 - BANNED: “It’s not X, it’s Y” contrasts. Em-dash clusters. Bullet lists as prose. “Game-changer”, “transformative”, “powerful”, “unlock”, “leverage”, “dive into”. Filler openers (“In today’s world”, “Here’s the thing”). Emoji stacking. Numbered listicles. Motivational closings.
 - Write like the user, not like an assistant helping the user.
@@ -1488,7 +1488,7 @@ if (TRANSPORT_MODE === "http") {
         name: "Quillby",
         description: "Guided Research & Insight Synthesis Tool — RSS content intelligence MCP server. Fetches, scores, and structures articles into content cards for social media posts.",
         url: `${baseUrl}/mcp`,
-        version: "0.3.4",
+        version: "0.4.0",
         capabilities: {
           streaming: true,
           pushNotifications: false,

--- a/src/output/structures.ts
+++ b/src/output/structures.ts
@@ -1,18 +1,17 @@
 import * as fs from "fs";
 import * as path from "path";
-import { CONFIG, ensureDir } from "../config.js";
+import { ensureDir } from "../config.js";
 import { HarvestBundleSchema, CardInputSchema, type HarvestBundle, type StructureCard, type CardInput } from "../types.js";
 import { saveSeenUrls } from "../extractors/rss.js";
-
-const CACHE_DIR = ".cache";
-const LATEST_HARVEST_POINTER = path.join(CACHE_DIR, "latest_harvest_path.txt");
+import { getCurrentWorkspaceId, getWorkspacePaths } from "../workspaces.js";
 
 function createTimestampedOutputDir(): string {
+  const paths = getWorkspacePaths(getCurrentWorkspaceId());
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, -5);
-  const outputDir = path.join(CONFIG.FILES.OUTPUT_DIR, timestamp);
+  const outputDir = path.join(paths.outputDir, timestamp);
   ensureDir(outputDir);
 
-  const latestLink = path.join(CONFIG.FILES.OUTPUT_DIR, "latest");
+  const latestLink = path.join(paths.outputDir, "latest");
   try {
     if (fs.existsSync(latestLink)) fs.unlinkSync(latestLink);
     fs.symlinkSync(timestamp, latestLink);
@@ -24,6 +23,7 @@ function createTimestampedOutputDir(): string {
 }
 
 export function saveHarvestOutput(rawCards: CardInput[], seenUrls: Set<string>): string {
+  const paths = getWorkspacePaths(getCurrentWorkspaceId());
   // Only persist if the caller actually passed URLs — calling with new Set()
   // would silently wipe the cache. Seen URLs should be saved by the fetch step.
   if (seenUrls.size > 0) saveSeenUrls(seenUrls);
@@ -53,8 +53,8 @@ export function saveHarvestOutput(rawCards: CardInput[], seenUrls: Set<string>):
   const markdown = buildMarkdown(cards, dateLabel);
   fs.writeFileSync(path.join(outputDir, "structures.md"), markdown + "\n");
 
-  ensureDir(CACHE_DIR);
-  fs.writeFileSync(LATEST_HARVEST_POINTER, path.join(outputDir, "structures.json"));
+  ensureDir(paths.cacheDir);
+  fs.writeFileSync(paths.latestHarvestPointer, path.join(outputDir, "structures.json"));
 
   return outputDir;
 }
@@ -102,13 +102,14 @@ function buildMarkdown(cards: StructureCard[], dateLabel: string): string {
 }
 
 export function loadLatestHarvest(): HarvestBundle {
-  if (!fs.existsSync(LATEST_HARVEST_POINTER)) {
+  const paths = getWorkspacePaths(getCurrentWorkspaceId());
+  if (!fs.existsSync(paths.latestHarvestPointer)) {
     throw new Error(
       "No harvest found. Run quillby_fetch_articles then quillby_save_cards first."
     );
   }
 
-  const bundlePath = fs.readFileSync(LATEST_HARVEST_POINTER, "utf-8").trim();
+  const bundlePath = fs.readFileSync(paths.latestHarvestPointer, "utf-8").trim();
   if (!bundlePath || !fs.existsSync(bundlePath)) {
     throw new Error("Latest harvest pointer is invalid. Re-run quillby_fetch_articles.");
   }
@@ -118,8 +119,9 @@ export function loadLatestHarvest(): HarvestBundle {
 }
 
 export function latestHarvestExists(): boolean {
-  if (!fs.existsSync(LATEST_HARVEST_POINTER)) return false;
-  const bundlePath = fs.readFileSync(LATEST_HARVEST_POINTER, "utf-8").trim();
+  const paths = getWorkspacePaths(getCurrentWorkspaceId());
+  if (!fs.existsSync(paths.latestHarvestPointer)) return false;
+  const bundlePath = fs.readFileSync(paths.latestHarvestPointer, "utf-8").trim();
   return Boolean(bundlePath) && fs.existsSync(bundlePath);
 }
 
@@ -128,11 +130,12 @@ export function saveDraft(
   platform: string,
   cardId?: number
 ): string {
-  const bundlePath = fs.existsSync(LATEST_HARVEST_POINTER)
-    ? fs.readFileSync(LATEST_HARVEST_POINTER, "utf-8").trim()
+  const paths = getWorkspacePaths(getCurrentWorkspaceId());
+  const bundlePath = fs.existsSync(paths.latestHarvestPointer)
+    ? fs.readFileSync(paths.latestHarvestPointer, "utf-8").trim()
     : null;
 
-  const outputDir = bundlePath ? path.dirname(bundlePath) : CONFIG.FILES.OUTPUT_DIR;
+  const outputDir = bundlePath ? path.dirname(bundlePath) : paths.outputDir;
   ensureDir(outputDir);
   const suffix = cardId != null ? `_card${cardId}` : "";
   const filePath = path.join(outputDir, `${platform.toLowerCase()}${suffix}.md`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,28 @@ export const UserMemorySchema = z.object({
 
 export type UserMemory = z.infer<typeof UserMemorySchema>;
 
+export const TypedMemorySchema = z.object({
+  voiceExamples: z.array(z.string()).default([]),
+  styleRules: z.array(z.string()).default([]),
+  audienceInsights: z.array(z.string()).default([]),
+  doNotSay: z.array(z.string()).default([]),
+  successfulPosts: z.array(z.string()).default([]),
+  campaignContext: z.array(z.string()).default([]),
+  sourcePreferences: z.array(z.string()).default([]),
+});
+
+export type TypedMemory = z.infer<typeof TypedMemorySchema>;
+
+export const WorkspaceMetadataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().default(""),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type WorkspaceMetadata = z.infer<typeof WorkspaceMetadataSchema>;
+
 // ─── RSS feed item ────────────────────────────────────────────────────────────
 
 export const RssItemSchema = z.object({

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -1,0 +1,296 @@
+import * as fs from "fs";
+import * as path from "path";
+import { z } from "zod";
+import { CONFIG, ensureDataDir, ensureDir } from "./config.js";
+import {
+  TypedMemorySchema,
+  UserContextSchema,
+  WorkspaceMetadataSchema,
+  type TypedMemory,
+  type UserContext,
+  type WorkspaceMetadata,
+} from "./types.js";
+
+const DEFAULT_WORKSPACE_ID = "default";
+
+function slugifyWorkspaceId(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || DEFAULT_WORKSPACE_ID;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function getWorkspaceDir(workspaceId: string): string {
+  return path.join(CONFIG.FILES.WORKSPACES_DIR, workspaceId);
+}
+
+export function getWorkspacePaths(workspaceId: string) {
+  const root = getWorkspaceDir(workspaceId);
+  return {
+    root,
+    meta: path.join(root, "workspace.json"),
+    context: path.join(root, "context.json"),
+    sources: path.join(root, "rss_sources.txt"),
+    outputDir: path.join(root, "output"),
+    cacheDir: path.join(root, ".cache"),
+    cache: path.join(root, ".cache", "seen_urls.json"),
+    latestHarvestPointer: path.join(root, ".cache", "latest_harvest_path.txt"),
+    memoryDir: path.join(root, "memory"),
+    typedMemory: path.join(root, "memory", "typed-memory.json"),
+  };
+}
+
+function ensureWorkspaceDirs(workspaceId: string) {
+  const paths = getWorkspacePaths(workspaceId);
+  ensureDataDir();
+  ensureDir(paths.root);
+  ensureDir(paths.outputDir);
+  ensureDir(paths.cacheDir);
+  ensureDir(paths.memoryDir);
+}
+
+function writeWorkspaceMeta(meta: WorkspaceMetadata) {
+  const parsed = WorkspaceMetadataSchema.parse(meta);
+  const paths = getWorkspacePaths(parsed.id);
+  ensureWorkspaceDirs(parsed.id);
+  fs.writeFileSync(paths.meta, JSON.stringify(parsed, null, 2));
+}
+
+function migrateLegacyStateIntoDefaultWorkspace() {
+  const legacyFiles = [
+    CONFIG.FILES.CONTEXT,
+    CONFIG.FILES.MEMORY,
+    CONFIG.FILES.SOURCES,
+    CONFIG.FILES.CACHE,
+  ];
+  const hasLegacyState = legacyFiles.some((file) => fs.existsSync(file));
+  if (!hasLegacyState || listWorkspaces().length > 0) return;
+
+  const createdAt = nowIso();
+  createWorkspace({
+    id: DEFAULT_WORKSPACE_ID,
+    name: "Default Workspace",
+    description: "Migrated from Quillby's legacy single-profile storage.",
+    makeCurrent: true,
+    createdAt,
+  });
+
+  const paths = getWorkspacePaths(DEFAULT_WORKSPACE_ID);
+  if (fs.existsSync(CONFIG.FILES.CONTEXT) && !fs.existsSync(paths.context)) {
+    fs.copyFileSync(CONFIG.FILES.CONTEXT, paths.context);
+  }
+  if (fs.existsSync(CONFIG.FILES.SOURCES) && !fs.existsSync(paths.sources)) {
+    fs.copyFileSync(CONFIG.FILES.SOURCES, paths.sources);
+  }
+  if (fs.existsSync(CONFIG.FILES.CACHE) && !fs.existsSync(paths.cache)) {
+    ensureDir(path.dirname(paths.cache));
+    fs.copyFileSync(CONFIG.FILES.CACHE, paths.cache);
+  }
+
+  if (fs.existsSync(CONFIG.FILES.MEMORY) && !fs.existsSync(paths.typedMemory)) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(CONFIG.FILES.MEMORY, "utf-8"));
+      const legacy = z.object({ voiceExamples: z.array(z.string()).default([]) }).parse(raw);
+      saveTypedMemory(DEFAULT_WORKSPACE_ID, {
+        voiceExamples: legacy.voiceExamples,
+      });
+    } catch {
+      saveTypedMemory(DEFAULT_WORKSPACE_ID, {});
+    }
+  }
+
+  const legacyOutputDir = path.join(CONFIG.DATA_DIR, "output");
+  if (fs.existsSync(legacyOutputDir) && fs.readdirSync(paths.outputDir).length === 0) {
+    for (const entry of fs.readdirSync(legacyOutputDir, { withFileTypes: true })) {
+      const source = path.join(legacyOutputDir, entry.name);
+      const target = path.join(paths.outputDir, entry.name);
+      if (entry.isDirectory()) {
+        fs.cpSync(source, target, { recursive: true });
+      } else if (entry.isSymbolicLink()) {
+        try {
+          const linked = fs.readlinkSync(source);
+          fs.symlinkSync(linked, target);
+        } catch {
+          // ignore unreadable legacy symlinks
+        }
+      } else if (entry.isFile()) {
+        fs.copyFileSync(source, target);
+      }
+    }
+  }
+
+  const legacyLatest = path.join(paths.outputDir, "latest", "structures.json");
+  if (fs.existsSync(legacyLatest) && !fs.existsSync(paths.latestHarvestPointer)) {
+    ensureDir(paths.cacheDir);
+    fs.writeFileSync(paths.latestHarvestPointer, legacyLatest);
+  }
+}
+
+export function ensureWorkspaceSystem() {
+  ensureDataDir();
+  migrateLegacyStateIntoDefaultWorkspace();
+  if (listWorkspaces().length === 0) {
+    createWorkspace({
+      id: DEFAULT_WORKSPACE_ID,
+      name: "Default Workspace",
+      description: "Primary Quillby workspace.",
+      makeCurrent: true,
+    });
+  }
+}
+
+export function listWorkspaces(): WorkspaceMetadata[] {
+  ensureDataDir();
+  if (!fs.existsSync(CONFIG.FILES.WORKSPACES_DIR)) return [];
+  return fs
+    .readdirSync(CONFIG.FILES.WORKSPACES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const metaPath = getWorkspacePaths(entry.name).meta;
+      if (fs.existsSync(metaPath)) {
+        try {
+          const raw = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+          return WorkspaceMetadataSchema.parse(raw);
+        } catch {
+          // fall through to rebuild minimal metadata
+        }
+      }
+      const fallback: WorkspaceMetadata = {
+        id: entry.name,
+        name: entry.name,
+        description: "",
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      };
+      writeWorkspaceMeta(fallback);
+      return fallback;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function workspaceExists(workspaceId: string): boolean {
+  return fs.existsSync(getWorkspacePaths(workspaceId).meta);
+}
+
+export function loadWorkspace(workspaceId: string): WorkspaceMetadata | null {
+  const metaPath = getWorkspacePaths(workspaceId).meta;
+  if (!fs.existsSync(metaPath)) return null;
+  try {
+    return WorkspaceMetadataSchema.parse(JSON.parse(fs.readFileSync(metaPath, "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+export function getCurrentWorkspaceId(): string {
+  ensureWorkspaceSystem();
+  if (fs.existsSync(CONFIG.FILES.CURRENT_WORKSPACE)) {
+    const workspaceId = fs.readFileSync(CONFIG.FILES.CURRENT_WORKSPACE, "utf-8").trim();
+    if (workspaceId && workspaceExists(workspaceId)) return workspaceId;
+  }
+  const fallback = listWorkspaces()[0]?.id ?? DEFAULT_WORKSPACE_ID;
+  setCurrentWorkspace(fallback);
+  return fallback;
+}
+
+export function getCurrentWorkspace(): WorkspaceMetadata {
+  return loadWorkspace(getCurrentWorkspaceId()) ?? createWorkspace({ id: DEFAULT_WORKSPACE_ID, name: "Default Workspace", makeCurrent: true });
+}
+
+export function setCurrentWorkspace(workspaceId: string): WorkspaceMetadata {
+  ensureWorkspaceSystem();
+  const workspace = loadWorkspace(workspaceId);
+  if (!workspace) {
+    throw new Error(`Workspace "${workspaceId}" does not exist.`);
+  }
+  fs.writeFileSync(CONFIG.FILES.CURRENT_WORKSPACE, workspaceId);
+  return workspace;
+}
+
+export function createWorkspace(input: {
+  id?: string;
+  name: string;
+  description?: string;
+  makeCurrent?: boolean;
+  createdAt?: string;
+}): WorkspaceMetadata {
+  ensureDataDir();
+  const workspaceId = slugifyWorkspaceId(input.id ?? input.name);
+  if (workspaceExists(workspaceId)) {
+    throw new Error(`Workspace "${workspaceId}" already exists.`);
+  }
+  const createdAt = input.createdAt ?? nowIso();
+  const meta: WorkspaceMetadata = {
+    id: workspaceId,
+    name: input.name.trim() || workspaceId,
+    description: input.description?.trim() ?? "",
+    createdAt,
+    updatedAt: createdAt,
+  };
+  ensureWorkspaceDirs(workspaceId);
+  writeWorkspaceMeta(meta);
+  saveTypedMemory(workspaceId, {});
+  if (input.makeCurrent) setCurrentWorkspace(workspaceId);
+  return meta;
+}
+
+export function touchWorkspace(workspaceId: string) {
+  const existing = loadWorkspace(workspaceId);
+  if (!existing) return;
+  writeWorkspaceMeta({ ...existing, updatedAt: nowIso() });
+}
+
+export function loadWorkspaceContext(workspaceId: string): UserContext | null {
+  const file = getWorkspacePaths(workspaceId).context;
+  if (!fs.existsSync(file)) return null;
+  try {
+    return UserContextSchema.parse(JSON.parse(fs.readFileSync(file, "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+export function saveWorkspaceContext(workspaceId: string, ctx: UserContext) {
+  const file = getWorkspacePaths(workspaceId).context;
+  ensureWorkspaceDirs(workspaceId);
+  fs.writeFileSync(file, JSON.stringify(UserContextSchema.parse(ctx), null, 2));
+  touchWorkspace(workspaceId);
+}
+
+export function loadTypedMemory(workspaceId: string): TypedMemory {
+  const file = getWorkspacePaths(workspaceId).typedMemory;
+  if (!fs.existsSync(file)) return TypedMemorySchema.parse({});
+  try {
+    return TypedMemorySchema.parse(JSON.parse(fs.readFileSync(file, "utf-8")));
+  } catch {
+    return TypedMemorySchema.parse({});
+  }
+}
+
+export function saveTypedMemory(workspaceId: string, partial: Partial<TypedMemory>) {
+  const current = loadTypedMemory(workspaceId);
+  const next = TypedMemorySchema.parse({ ...current, ...partial });
+  const file = getWorkspacePaths(workspaceId).typedMemory;
+  ensureWorkspaceDirs(workspaceId);
+  fs.writeFileSync(file, JSON.stringify(next, null, 2));
+  touchWorkspace(workspaceId);
+}
+
+export function appendTypedMemory(
+  workspaceId: string,
+  memoryType: keyof TypedMemory,
+  entries: string[],
+  limit?: number
+) {
+  const current = loadTypedMemory(workspaceId);
+  const existing = current[memoryType];
+  const deduped = [...new Set([...entries, ...existing].map((entry) => entry.trim()).filter(Boolean))];
+  const next = limit != null ? deduped.slice(0, limit) : deduped;
+  saveTypedMemory(workspaceId, { [memoryType]: next } as Partial<TypedMemory>);
+}

--- a/tests/integration/mcp-protocol.test.ts
+++ b/tests/integration/mcp-protocol.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawn, type ChildProcess } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), "../../../");
@@ -31,10 +32,11 @@ class McpTestClient {
   private buf = "";
   private pending = new Map<number, (res: JsonRpcResponse) => void>();
 
-  constructor() {
+  constructor(dataDir: string) {
     this.proc = spawn("node", [SERVER_BIN], {
       stdio: ["pipe", "pipe", "pipe"],
       cwd: ROOT,
+      env: { ...process.env, QUILLBY_HOME: dataDir },
     });
     this.proc.stderr?.on("data", () => {}); // suppress startup logs
     this.proc.stdout?.on("data", (chunk: Buffer) => {
@@ -80,6 +82,7 @@ class McpTestClient {
 // ─── Suite setup ──────────────────────────────────────────────────────────────
 
 let client: McpTestClient;
+let tempDir: string;
 
 beforeAll(() => {
   if (!fs.existsSync(SERVER_BIN)) {
@@ -87,11 +90,13 @@ beforeAll(() => {
       `Built server not found at ${SERVER_BIN}.\nRun 'npm run build' before the integration tests.`,
     );
   }
-  client = new McpTestClient();
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-mcp-test-"));
+  client = new McpTestClient(tempDir);
 });
 
 afterAll(() => {
   client?.close();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -144,11 +149,15 @@ describe("MCP tools/list", () => {
     tools = (res.result as { tools: typeof tools }).tools;
   });
 
-  it("returns exactly 16 tools", () => {
-    expect(tools).toHaveLength(16);
+  it("returns the expanded toolset", () => {
+    expect(tools.length).toBeGreaterThanOrEqual(21);
   });
 
   it.each([
+    "quillby_list_workspaces",
+    "quillby_create_workspace",
+    "quillby_select_workspace",
+    "quillby_get_workspace",
     "quillby_onboard",
     "quillby_set_context",
     "quillby_get_context",
@@ -158,6 +167,7 @@ describe("MCP tools/list", () => {
     "quillby_analyze_articles",
     "quillby_generate_post",
     "quillby_remember",
+    "quillby_get_memory",
   ])('tool "%s" is present', (name) => {
     expect(tools.map((t) => t.name)).toContain(name);
   });
@@ -176,15 +186,15 @@ describe("MCP tools/list", () => {
 });
 
 describe("MCP prompts/list", () => {
-  it("returns at least 2 prompts", async () => {
+  it("returns the project-oriented prompts", async () => {
     const res = await client.request({
       jsonrpc: "2.0",
       id: 3,
       method: "prompts/list",
       params: {},
     });
-    const prompts = (res.result as { prompts: unknown[] }).prompts;
-    expect(prompts.length).toBeGreaterThanOrEqual(2);
+    const prompts = (res.result as { prompts: { name: string }[] }).prompts;
+    expect(prompts.map((prompt) => prompt.name)).toContain("quillby_projects_playbook");
   });
 });
 
@@ -194,7 +204,7 @@ describe("quillby_remember tool call", () => {
       jsonrpc: "2.0",
       id: 4,
       method: "tools/call",
-      params: { name: "quillby_remember", arguments: { voiceExamples: ["Test voice example."] } },
+      params: { name: "quillby_remember", arguments: { entries: ["Test voice example."], memoryType: "voice_examples" } },
     });
     expect(res.error).toBeUndefined();
     const content = (res.result as { content: { type: string; text: string }[] }).content;

--- a/tests/integration/mcp-protocol.test.ts
+++ b/tests/integration/mcp-protocol.test.ts
@@ -120,7 +120,7 @@ describe("MCP initialize", () => {
     );
     expect(
       (res.result as { serverInfo: { name: string; version: string } }).serverInfo.version,
-    ).toBe("0.3.4");
+    ).toBe("0.4.0");
   });
 });
 

--- a/tests/unit/structures.test.ts
+++ b/tests/unit/structures.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../src/output/structures.js";
 import { CardInputSchema, type CardInput } from "../../src/types.js";
 import * as rss from "../../src/extractors/rss.js";
+import { getWorkspacePaths } from "../../src/workspaces.js";
 
 // ─── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -44,13 +45,12 @@ let originalCwd: string;
 beforeEach(() => {
   originalCwd = process.cwd();
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-test-"));
-  // Seed the required dirs so config.ts side-effects are satisfied locally
-  fs.mkdirSync(path.join(tempDir, ".cache"), { recursive: true });
-  fs.mkdirSync(path.join(tempDir, "output"), { recursive: true });
+  process.env.QUILLBY_HOME = tempDir;
   process.chdir(tempDir);
 });
 
 afterEach(() => {
+  delete process.env.QUILLBY_HOME;
   process.chdir(originalCwd);
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
@@ -113,7 +113,7 @@ describe("saveHarvestOutput", () => {
 
   it("writes the latest harvest pointer file", () => {
     saveHarvestOutput([makeCard()], new Set());
-    const pointer = path.join(".cache", "latest_harvest_path.txt");
+    const pointer = getWorkspacePaths("default").latestHarvestPointer;
     expect(fs.existsSync(pointer)).toBe(true);
     const pointerValue = fs.readFileSync(pointer, "utf-8").trim();
     expect(pointerValue).toMatch(/structures\.json$/);
@@ -187,7 +187,7 @@ describe("loadLatestHarvest", () => {
   it("throws with clear message when pointer points to missing file", () => {
     saveHarvestOutput([makeCard()], new Set());
     // Corrupt the pointer
-    fs.writeFileSync(".cache/latest_harvest_path.txt", "/nonexistent/path.json");
+    fs.writeFileSync(getWorkspacePaths("default").latestHarvestPointer, "/nonexistent/path.json");
     expect(() => loadLatestHarvest()).toThrow(/invalid|Re-run/i);
   });
 });

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -30,14 +30,14 @@ const claudeConfigPath = {
 
     <!-- Primary SEO -->
     <title>Quillby — Your AI Content Agent</title>
-    <meta name="description" content="Quillby reads your feeds, filters what matters, and delivers fresh drafts in your voice — every day." />
+    <meta name="description" content="Quillby reads your feeds, filters what matters, and delivers fresh drafts in your voice — with one workspace per project, client, or brand." />
     <link rel="canonical" href="https://quillby.vercel.app/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://quillby.vercel.app/" />
     <meta property="og:title" content="Quillby — Your AI Content Agent" />
-    <meta property="og:description" content="Reads the internet. Filters for you. Writes in your voice." />
+    <meta property="og:description" content="Reads the internet. Filters for you. Writes in your voice, with one workspace per project." />
     <meta property="og:image" content="https://quillby.vercel.app/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -48,7 +48,7 @@ const claudeConfigPath = {
     <!-- Twitter / X Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Quillby — Your AI Content Agent" />
-    <meta name="twitter:description" content="Reads the internet. Filters for you. Writes in your voice." />
+    <meta name="twitter:description" content="Reads the internet. Filters for you. Writes in your voice, with one workspace per project." />
     <meta name="twitter:image" content="https://quillby.vercel.app/og.png" />
     <meta name="twitter:image:alt" content="Quillby — Your AI Content Agent" />
 
@@ -581,13 +581,13 @@ const claudeConfigPath = {
           <em>your next post.</em>
         </h1>
         <p class="hero-sub">
-          Ask Claude <strong>"what should I post today?"</strong> and get a ranked brief and a ready-to-publish draft — sourced from your feeds, filtered for your audience, written in your voice.
+          Ask Claude <strong>"what should I post today?"</strong> and get a ranked brief and a ready-to-publish draft — sourced from your feeds, filtered for your audience, written in your voice. Use one workspace per client, brand, newsletter, or Claude Project.
         </p>
         <div class="hero-actions">
           <a href="#install" class="btn-primary">Install free →</a>
           <a href="https://github.com/vncsleal/quillby" target="_blank" rel="noopener" class="btn-secondary">View on GitHub ↗</a>
         </div>
-        <p class="hero-proof">Free forever · MIT License · No new apps</p>
+        <p class="hero-proof">Free forever · Local-first · Multiple workspaces · No new apps</p>
       </div>
 
       <div class="hero-visual">
@@ -645,9 +645,9 @@ const claudeConfigPath = {
         <div class="steps-row">
           {[
             { n:'01', g:'⬇', title:'Install', desc:'Download the installer for your platform. Quillby wires itself into Claude Desktop automatically — no Terminal required.' },
-            { n:'02', g:'◎', title:'Set up your profile', desc:'Tell Claude your industry, audience, and voice. Two minutes. Saved forever — update anytime you want.' },
-            { n:'03', g:'⌗', title:'Quillby reads the internet', desc:'RSS, Reddit, and Medium feeds are fetched, ranked by relevance to your profile, and surfaced as a content brief.' },
-            { n:'04', g:'↑', title:'Publish in your voice', desc:'Request a draft. Claude writes it from your profile and the sourced article. Edit, approve, post.' },
+            { n:'02', g:'◎', title:'Set up a workspace', desc:'Create one workspace per client, brand, newsletter, or Claude Project. Each one gets its own profile, memory, feeds, and drafts.' },
+            { n:'03', g:'⌗', title:'Quillby reads the internet', desc:'RSS, Reddit, and Medium feeds are fetched, ranked by relevance to that workspace, and surfaced as a content brief.' },
+            { n:'04', g:'↑', title:'Publish in your voice', desc:'Request a draft. Claude writes it from the workspace profile, memory, and sourced article. Edit, approve, post.' },
           ].map(s => (
             <div data-reveal class="step-card">
               <div class="step-num">{s.n}</div>
@@ -698,8 +698,8 @@ const claudeConfigPath = {
             <div class="feat-icon">
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
             </div>
-            <h3 class="feat-title">Works where you work</h3>
-            <p class="feat-desc">No new app. No new tab. Quillby lives inside Claude Desktop — ask it anything in plain language.</p>
+            <h3 class="feat-title">One workspace per context</h3>
+            <p class="feat-desc">Keep client work, personal brand, newsletters, and campaigns separated. Each workspace has its own profile, memory, feeds, and outputs.</p>
           </div>
           <div data-reveal class="feat-card">
             <div class="feat-icon">
@@ -770,9 +770,9 @@ const claudeConfigPath = {
           <div class="install-steps">
             {[
               { n:'1', t:'Install & restart Claude Desktop', b:'Run the installer, then fully quit and reopen Claude Desktop. Quillby loads automatically on startup.' },
-              { n:'2', t:'Run onboarding', b:'Say "Set me up with Quillby" in Claude. It asks a few questions about your industry, audience, and voice — done in two minutes.' },
-              { n:'3', t:'Discover your sources', b:'Quillby finds and subscribes to relevant RSS feeds, Reddit communities, and Medium articles for your niche automatically.' },
-              { n:'4', t:'Ask what to post', b:'Every morning: "what should I post today?" — Quillby reads your feeds, ranks what\'s relevant, and writes a draft ready to publish.' },
+              { n:'2', t:'Create your first workspace', b:'Say "Set me up with Quillby" in Claude. For new users, Quillby creates a default workspace and saves your profile there.' },
+              { n:'3', t:'Discover your sources', b:'Quillby finds and subscribes to relevant RSS feeds, Reddit communities, and Medium articles for that workspace automatically.' },
+              { n:'4', t:'Ask what to post', b:'Every morning: "what should I post today?" — Quillby reads that workspace\'s feeds, ranks what\'s relevant, and writes a draft ready to publish.' },
             ].map(s => (
               <div data-reveal class="install-step">
                 <div class="install-step-num">{s.n}</div>


### PR DESCRIPTION
## Summary
- add workspace-scoped local storage with automatic migration from legacy single-profile state
- expand the MCP surface with workspace management and typed memory tools/resources/prompts
- update docs and tests for the local multi-workspace model and configurable QUILLBY_HOME data root

## Testing
- npm run test:all