### PR TITLE
refactor: extract profile tool handlers from server.ts into src/mcp/tools/

### DIFF
--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -81,10 +81,9 @@ import {
   handleSessionClose,
 } from "./sessions.js";
 import {
-  toolDefinitions as _profileToolDefinitions,
+  toolDefinitions as profileToolDefinitions,
   handleProfileTool,
 } from "./tools/profile.js";
-const profileToolDefinitions = _profileToolDefinitions as Tool[];
 import type { PlanStorage, SessionStore } from "@quillby/workspace";
 import {
   buildDirectAdaptersFromConfig,
@@ -936,7 +935,7 @@ async function handleToolCall(
     ]);
 
     if (PROFILE_TOOL_NAMES.has(name)) {
-      return handleProfileTool(name, args, { server, storage, deploymentMode: deploymentMode as "local" | "self-hosted" | "cloud", providerRouter });
+      return handleProfileTool(name, args, { server, storage, deploymentMode, providerRouter });
     }
 
     switch (name) {

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -42,7 +42,6 @@ import {
   McpSamplingAdapter,
   initCloudAdapters,
   getProviderPolicyReport,
-  ElevenLabsAdapter,
   validateUrl,
 } from "@quillby/providers";
 import type { GenerationModality } from "@quillby/core";
@@ -55,8 +54,6 @@ import {
   GetProvidersArgsSchema, // eslint-disable-line @typescript-eslint/no-unused-vars
   SetProviderArgsSchema,
   ClearProviderArgsSchema,
-  SetCloneIdentityArgsSchema,
-  CloneVoiceArgsSchema,
   DeleteVoiceCloneArgsSchema, // eslint-disable-line @typescript-eslint/no-unused-vars
   PlanCreateArgsSchema, // eslint-disable-line @typescript-eslint/no-unused-vars
   PlanListArgsSchema, // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -83,13 +80,17 @@ import {
   handleSessionStatus,
   handleSessionClose,
 } from "./sessions.js";
+import {
+  toolDefinitions as _profileToolDefinitions,
+  handleProfileTool,
+} from "./tools/profile.js";
+const profileToolDefinitions = _profileToolDefinitions as Tool[];
 import type { PlanStorage, SessionStore } from "@quillby/workspace";
 import {
   buildDirectAdaptersFromConfig,
   clearProviderConfig,
   getStoredProviderConfigSummary,
   saveProviderConfig,
-  resolveElevenLabsApiKey,
   verifyProviderEnv,
 } from "../provider-config.js";
 
@@ -231,137 +232,7 @@ const TOOLS: Tool[] = [
     inputSchema: { type: "object", properties: {} },
   },
 
-  // ── Profile ───────────────────────────────────────────────────────────────
-  {
-    name: "quillby_list_workspaces",
-    description: "List Quillby workspaces. Use one workspace per Claude Project, client, publication, or campaign.",
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: { type: "object", properties: {} },
-  },
-  {
-    name: "quillby_create_workspace",
-    description: "Create a workspace with isolated context, memories, feeds, and outputs.",
-    annotations: { destructiveHint: false },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        workspaceId: { type: "string" },
-        description: { type: "string" },
-        makeCurrent: { type: "boolean" },
-      },
-      required: ["name"],
-    },
-  },
-  {
-    name: "quillby_select_workspace",
-    description: "Switch the active Quillby workspace.",
-    annotations: { destructiveHint: false, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string" },
-      },
-      required: ["workspaceId"],
-    },
-  },
-  {
-    name: "quillby_get_workspace",
-    description: "Inspect the active workspace or a specific workspace.",
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string" },
-      },
-    },
-  },
-  {
-    name: "quillby_set_clone_identity",
-    description: "Set workspace-level identity clone references (face image URL and voice audio URL) and explicit consent flag. Clone generation will be blocked unless consent is granted.",
-    annotations: { destructiveHint: false, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
-        faceReferenceImageUrl: { type: "string", description: "Publicly reachable image URL of the consenting user's face reference." },
-        voiceReferenceAudioUrl: { type: "string", description: "Publicly reachable audio URL of the consenting user's voice sample." },
-        cloneConsentGranted: { type: "boolean", description: "Must be true before identity clone generation is allowed." },
-      },
-      required: ["cloneConsentGranted"],
-    },
-  },
-  {
-    name: "quillby_clone_voice",
-    description: "Create a persistent ElevenLabs voice clone from the workspace voice reference audio URL. Uploads the audio to ElevenLabs once and stores the returned voiceId in workspace metadata for all subsequent audio generation calls. Requires clone consent to be granted and an ElevenLabs provider to be configured. Idempotent — if a cloned voice ID is already saved, returns it without re-cloning unless overwrite is true.",
-    annotations: { destructiveHint: false, idempotentHint: false },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
-        name: { type: "string", description: "Display name for the cloned voice in ElevenLabs. Defaults to the workspace name." },
-        overwrite: { type: "boolean", description: "If true, delete the existing cloned voice and create a fresh one. Defaults to false." },
-      },
-    },
-  },
-  {
-    name: "quillby_delete_voice_clone",
-    description: "Delete the persistent ElevenLabs voice clone associated with this workspace. Removes the voice from ElevenLabs and clears the stored voiceId. Consent and reference URL are preserved so you can re-clone later.",
-    annotations: { destructiveHint: true, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
-      },
-    },
-  },
-  {
-    name: "quillby_set_context",
-    description: "Save the user content creator profile after onboarding.",
-    annotations: { destructiveHint: false, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
-        context: {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            role: { type: "string" },
-            industry: { type: "string" },
-            topics: { type: "array", items: { type: "string" } },
-            voice: { type: "string" },
-            audienceDescription: { type: "string" },
-            contentGoals: { type: "array", items: { type: "string" } },
-            excludeTopics: { type: "array", items: { type: "string" } },
-            platforms: { type: "array", items: { type: "string" } },
-          },
-          required: ["role", "industry", "topics", "voice", "audienceDescription", "contentGoals", "platforms"],
-        },
-      },
-      required: ["context"],
-    },
-  },
-  {
-    name: "quillby_get_context",
-    description: "Load the saved user profile.",
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
-      },
-    },
-  },
+  ...profileToolDefinitions,
 
   // ── Feeds ─────────────────────────────────────────────────────────────────
   {
@@ -1058,220 +929,17 @@ async function handleToolCall(
       return storage.withWorkspace(workspaceId) as Promise<WorkspaceStorage & JobStorage>;
     };
 
+    const PROFILE_TOOL_NAMES = new Set([
+      "quillby_list_workspaces", "quillby_create_workspace", "quillby_select_workspace",
+      "quillby_get_workspace", "quillby_set_clone_identity", "quillby_clone_voice",
+      "quillby_delete_voice_clone", "quillby_set_context", "quillby_get_context",
+    ]);
+
+    if (PROFILE_TOOL_NAMES.has(name)) {
+      return handleProfileTool(name, args, { server, storage, deploymentMode: deploymentMode as "local" | "self-hosted" | "cloud", providerRouter });
+    }
+
     switch (name) {
-      case "quillby_list_workspaces": {
-        const currentWorkspaceId = await storage.getCurrentWorkspaceId();
-        const workspaces = (await storage.listWorkspaces()).map((workspace) => ({
-          ...workspace,
-          current: workspace.id === currentWorkspaceId,
-        }));
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ currentWorkspaceId, workspaces }, null, 2) }],
-          structuredContent: { currentWorkspaceId, workspaces },
-        };
-      }
-
-      case "quillby_create_workspace": {
-        const { name: workspaceName, workspaceId, description, makeCurrent } = args as {
-          name: string;
-          workspaceId?: string;
-          description?: string;
-          makeCurrent?: boolean;
-        };
-        const workspace = await storage.createWorkspace({
-          id: workspaceId,
-          name: workspaceName,
-          description,
-          makeCurrent: makeCurrent ?? true,
-        });
-        return {
-          content: [{ type: "text" as const, text: `Workspace "${workspace.name}" created with id "${workspace.id}".` }],
-          structuredContent: workspace,
-        };
-      }
-
-      case "quillby_select_workspace": {
-        const { workspaceId } = args as { workspaceId: string };
-        const workspace = await storage.setCurrentWorkspace(workspaceId);
-        return {
-          content: [{ type: "text" as const, text: `Current workspace set to "${workspace.name}" (${workspace.id}).` }],
-          structuredContent: workspace,
-        };
-      }
-
-      case "quillby_get_workspace": {
-        const activeStorage = await resolveStorage();
-        const workspace = await activeStorage.getCurrentWorkspace();
-        const [ctx, mem, sources] = await Promise.all([
-          activeStorage.loadContext(),
-          activeStorage.loadTypedMemory(),
-          activeStorage.loadSources(),
-        ]);
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({
-              workspace,
-              current: true,
-              context: ctx,
-              memory: mem,
-              feedCount: sources.length,
-            }, null, 2),
-          }],
-          structuredContent: {
-            workspace,
-            current: true,
-            context: ctx,
-            memory: mem,
-            feedCount: sources.length,
-          },
-        };
-      }
-
-      case "quillby_set_clone_identity": {
-        const activeStorage = await resolveStorage();
-        const parsedIc = SetCloneIdentityArgsSchema.parse(args);
-        const {
-          faceReferenceImageUrl,
-          voiceReferenceAudioUrl,
-          cloneConsentGranted,
-        } = parsedIc;
-
-        if (faceReferenceImageUrl !== undefined) {
-          try {
-            await validateUrl(faceReferenceImageUrl);
-          } catch (err) {
-            throw new Error(`faceReferenceImageUrl validation failed: ${err instanceof Error ? err.message : "invalid URL"}`);
-          }
-        }
-        if (voiceReferenceAudioUrl !== undefined) {
-          try {
-            await validateUrl(voiceReferenceAudioUrl);
-          } catch (err) {
-            throw new Error(`voiceReferenceAudioUrl validation failed: ${err instanceof Error ? err.message : "invalid URL"}`);
-          }
-        }
-
-        const workspace = await activeStorage.updateWorkspaceMetadata({
-          ...(faceReferenceImageUrl !== undefined && { faceReferenceImageUrl }),
-          ...(voiceReferenceAudioUrl !== undefined && { voiceReferenceAudioUrl }),
-          cloneConsentGranted,
-          cloneConsentAt: cloneConsentGranted ? new Date().toISOString() : undefined,
-        });
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({
-              workspaceId: workspace.id,
-              cloneConsentGranted: workspace.cloneConsentGranted,
-              faceReferenceImageUrl: workspace.faceReferenceImageUrl,
-              voiceReferenceAudioUrl: workspace.voiceReferenceAudioUrl,
-              cloneConsentAt: workspace.cloneConsentAt,
-            }, null, 2),
-          }],
-          structuredContent: {
-            workspaceId: workspace.id,
-            cloneConsentGranted: workspace.cloneConsentGranted,
-            faceReferenceImageUrl: workspace.faceReferenceImageUrl,
-            voiceReferenceAudioUrl: workspace.voiceReferenceAudioUrl,
-            cloneConsentAt: workspace.cloneConsentAt,
-          },
-        };
-      }
-
-      case "quillby_clone_voice": {
-        const activeStorage = await resolveStorage();
-        const parsedCv = CloneVoiceArgsSchema.parse(args);
-        const { name: voiceName, overwrite } = parsedCv;
-        const workspace = await activeStorage.getCurrentWorkspace();
-
-        if (!workspace.cloneConsentGranted) {
-          throw new Error("Clone consent must be granted before creating a voice clone. Call quillby_set_clone_identity first.");
-        }
-        if (!workspace.voiceReferenceAudioUrl) {
-          throw new Error("No voiceReferenceAudioUrl set. Call quillby_set_clone_identity with a voice sample URL first.");
-        }
-
-        const elevenLabsApiKey = resolveElevenLabsApiKey(deploymentMode);
-        if (!elevenLabsApiKey) {
-          throw new Error("ElevenLabs is not configured. Set QUILLBY_ELEVENLABS_API_KEY or configure the audio provider via quillby_set_provider.");
-        }
-
-        // Idempotent: return existing clone ID unless overwrite is requested.
-        if (workspace.elevenlabsClonedVoiceId && !overwrite) {
-          return {
-            content: [{
-              type: "text" as const,
-              text: JSON.stringify({
-                workspaceId: workspace.id,
-                elevenlabsClonedVoiceId: workspace.elevenlabsClonedVoiceId,
-                status: "already_cloned",
-              }, null, 2),
-            }],
-            structuredContent: {
-              workspaceId: workspace.id,
-              elevenlabsClonedVoiceId: workspace.elevenlabsClonedVoiceId,
-              status: "already_cloned",
-            },
-          };
-        }
-
-        // Delete old clone if overwrite requested.
-        if (workspace.elevenlabsClonedVoiceId && overwrite) {
-          await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId).catch(() => process.stderr.write("[quillby] Non-fatal: could not delete old ElevenLabs voice clone\n"));
-        }
-
-        const cloneName = voiceName?.trim() || workspace.name || "Quillby Voice Clone";
-        const clonedVoiceId = await ElevenLabsAdapter.createVoiceClone(
-          elevenLabsApiKey,
-          workspace.voiceReferenceAudioUrl,
-          cloneName
-        );
-
-        const updated = await activeStorage.updateWorkspaceMetadata({ elevenlabsClonedVoiceId: clonedVoiceId });
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({
-              workspaceId: updated.id,
-              elevenlabsClonedVoiceId: updated.elevenlabsClonedVoiceId,
-              status: "cloned",
-            }, null, 2),
-          }],
-          structuredContent: {
-            workspaceId: updated.id,
-            elevenlabsClonedVoiceId: updated.elevenlabsClonedVoiceId,
-            status: "cloned",
-          },
-        };
-      }
-
-      case "quillby_delete_voice_clone": {
-        const activeStorage = await resolveStorage();
-        const workspace = await activeStorage.getCurrentWorkspace();
-
-        if (!workspace.elevenlabsClonedVoiceId) {
-          return {
-            content: [{ type: "text" as const, text: JSON.stringify({ workspaceId: workspace.id, status: "no_clone" }, null, 2) }],
-            structuredContent: { workspaceId: workspace.id, status: "no_clone" },
-          };
-        }
-
-        const elevenLabsApiKey = resolveElevenLabsApiKey(deploymentMode);
-        if (elevenLabsApiKey) {
-          await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId).catch(() => process.stderr.write("[quillby] Non-fatal: ElevenLabs deleteVoiceClone failed in delete handler\n"));
-        }
-
-        await activeStorage.updateWorkspaceMetadata({ elevenlabsClonedVoiceId: "" });
-
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ workspaceId: workspace.id, status: "deleted" }, null, 2) }],
-          structuredContent: { workspaceId: workspace.id, status: "deleted" },
-        };
-      }
-
       case "quillby_onboard": {
         const caps = server.server.getClientCapabilities();
         if (!caps?.elicitation?.form) {

--- a/apps/mcp-server/src/mcp/tools/index.ts
+++ b/apps/mcp-server/src/mcp/tools/index.ts
@@ -1,5 +1,4 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { ProviderRouter } from "@quillby/providers";
 
 export interface ToolStorage {
@@ -7,29 +6,27 @@ export interface ToolStorage {
   listWorkspaces(): Promise<{ id: string; name: string; current?: boolean }[]>;
   createWorkspace(opts: { id?: string; name: string; description?: string; makeCurrent?: boolean }): Promise<{ id: string; name: string }>;
   setCurrentWorkspace(id: string): Promise<{ id: string; name: string }>;
-  getCurrentWorkspace(): Promise<Record<string, unknown>>;
+  getCurrentWorkspace(): Promise<{ id: string; name: string; [key: string]: unknown }>;
   withWorkspace(id: string): Promise<ToolStorage>;
+  contextExists(): Promise<boolean>;
   loadContext(): Promise<Record<string, unknown> | null>;
   saveContext(ctx: Record<string, unknown>): Promise<void>;
   loadTypedMemory(): Promise<Record<string, unknown> | null>;
   loadSources(): Promise<unknown[]>;
-  updateWorkspaceMetadata(meta: Record<string, unknown>): Promise<Record<string, unknown>>;
+  updateWorkspaceMetadata(meta: Record<string, unknown>): Promise<{ id: string; [key: string]: unknown }>;
 }
+
+import type { DeploymentMode } from "@quillby/config";
 
 export interface ToolContext {
   server: McpServer;
   storage: ToolStorage;
-  deploymentMode: string;
+  deploymentMode: DeploymentMode;
   providerRouter: ProviderRouter;
 }
 
 export type ToolResult = {
-  content: { type: "text"; text: string }[];
+  content: { type: "text"; text: string; annotations?: Record<string, unknown>; _meta?: Record<string, unknown> }[];
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
-
-export interface ToolModule {
-  toolDefinitions: Partial<Tool>[];
-  handleTool(name: string, args: Record<string, unknown>, ctx: ToolContext): Promise<ToolResult>;
-}

--- a/apps/mcp-server/src/mcp/tools/index.ts
+++ b/apps/mcp-server/src/mcp/tools/index.ts
@@ -1,0 +1,35 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { ProviderRouter } from "@quillby/providers";
+
+export interface ToolStorage {
+  getCurrentWorkspaceId(): Promise<string>;
+  listWorkspaces(): Promise<{ id: string; name: string; current?: boolean }[]>;
+  createWorkspace(opts: { id?: string; name: string; description?: string; makeCurrent?: boolean }): Promise<{ id: string; name: string }>;
+  setCurrentWorkspace(id: string): Promise<{ id: string; name: string }>;
+  getCurrentWorkspace(): Promise<Record<string, unknown>>;
+  withWorkspace(id: string): Promise<ToolStorage>;
+  loadContext(): Promise<Record<string, unknown> | null>;
+  saveContext(ctx: Record<string, unknown>): Promise<void>;
+  loadTypedMemory(): Promise<Record<string, unknown> | null>;
+  loadSources(): Promise<unknown[]>;
+  updateWorkspaceMetadata(meta: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+export interface ToolContext {
+  server: McpServer;
+  storage: ToolStorage;
+  deploymentMode: string;
+  providerRouter: ProviderRouter;
+}
+
+export type ToolResult = {
+  content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+export interface ToolModule {
+  toolDefinitions: Partial<Tool>[];
+  handleTool(name: string, args: Record<string, unknown>, ctx: ToolContext): Promise<ToolResult>;
+}

--- a/apps/mcp-server/src/mcp/tools/profile.ts
+++ b/apps/mcp-server/src/mcp/tools/profile.ts
@@ -5,7 +5,7 @@ import { resolveElevenLabsApiKey } from "../../provider-config.js";
 import { SetCloneIdentityArgsSchema, CloneVoiceArgsSchema } from "../schemas.js";
 import type { ToolContext } from "./index.js";
 
-export const toolDefinitions: Partial<Tool>[] = [
+export const toolDefinitions: Tool[] = [
   {
     name: "quillby_list_workspaces",
     description: "List Quillby workspaces. Use one workspace per Claude Project, client, publication, or campaign.",
@@ -52,42 +52,42 @@ export const toolDefinitions: Partial<Tool>[] = [
   },
   {
     name: "quillby_set_clone_identity",
-    description: "Set workspace-level identity clone references and consent.",
+    description: "Set workspace-level identity clone references (face image URL and voice audio URL) and explicit consent flag. Clone generation will be blocked unless consent is granted.",
     annotations: { destructiveHint: false, idempotentHint: true },
     outputSchema: { type: "object" as const },
     inputSchema: {
       type: "object",
       properties: {
-        workspaceId: { type: "string" },
-        faceReferenceImageUrl: { type: "string" },
-        voiceReferenceAudioUrl: { type: "string" },
-        cloneConsentGranted: { type: "boolean" },
+        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
+        faceReferenceImageUrl: { type: "string", description: "Publicly reachable image URL of the consenting user's face reference." },
+        voiceReferenceAudioUrl: { type: "string", description: "Publicly reachable audio URL of the consenting user's voice sample." },
+        cloneConsentGranted: { type: "boolean", description: "Must be true before identity clone generation is allowed." },
       },
       required: ["cloneConsentGranted"],
     },
   },
   {
     name: "quillby_clone_voice",
-    description: "Create a persistent ElevenLabs voice clone.",
+    description: "Create a persistent ElevenLabs voice clone from the workspace voice reference audio URL. Uploads the audio to ElevenLabs once and stores the returned voiceId in workspace metadata for all subsequent audio generation calls. Requires clone consent to be granted and an ElevenLabs provider to be configured. Idempotent — if a cloned voice ID is already saved, returns it without re-cloning unless overwrite is true.",
     annotations: { destructiveHint: false, idempotentHint: false },
     outputSchema: { type: "object" as const },
     inputSchema: {
       type: "object",
       properties: {
-        workspaceId: { type: "string" },
-        name: { type: "string" },
-        overwrite: { type: "boolean" },
+        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
+        name: { type: "string", description: "Display name for the cloned voice in ElevenLabs. Defaults to the workspace name." },
+        overwrite: { type: "boolean", description: "If true, delete the existing cloned voice and create a fresh one. Defaults to false." },
       },
     },
   },
   {
     name: "quillby_delete_voice_clone",
-    description: "Delete the persistent ElevenLabs voice clone.",
+    description: "Delete the persistent ElevenLabs voice clone associated with this workspace. Removes the voice from ElevenLabs and clears the stored voiceId. Consent and reference URL are preserved so you can re-clone later.",
     annotations: { destructiveHint: true, idempotentHint: true },
     outputSchema: { type: "object" as const },
     inputSchema: {
       type: "object",
-      properties: { workspaceId: { type: "string" } },
+      properties: { workspaceId: { type: "string", description: "Optional workspace override without changing global selection." } },
     },
   },
   {
@@ -98,7 +98,7 @@ export const toolDefinitions: Partial<Tool>[] = [
     inputSchema: {
       type: "object",
       properties: {
-        workspaceId: { type: "string" },
+        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
         context: {
           type: "object",
           properties: {
@@ -125,7 +125,7 @@ export const toolDefinitions: Partial<Tool>[] = [
     outputSchema: { type: "object" as const },
     inputSchema: {
       type: "object",
-      properties: { workspaceId: { type: "string" } },
+      properties: { workspaceId: { type: "string", description: "Optional workspace override without changing global selection." } },
     },
   },
 ];
@@ -279,7 +279,7 @@ export function handleProfileTool(
           throw new Error("No voiceReferenceAudioUrl set. Call quillby_set_clone_identity with a voice sample URL first.");
         }
 
-        const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode as "local" | "self-hosted" | "cloud");
+        const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode);
         if (!elevenLabsApiKey) {
           throw new Error("ElevenLabs is not configured. Set QUILLBY_ELEVENLABS_API_KEY or configure the audio provider via quillby_set_provider.");
         }
@@ -338,7 +338,7 @@ export function handleProfileTool(
           };
         }
 
-        const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode as "local" | "self-hosted" | "cloud");
+        const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode);
         if (elevenLabsApiKey) {
           await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId)
             .catch(() => process.stderr.write("[quillby] Non-fatal: ElevenLabs deleteVoiceClone failed in delete handler\n"));
@@ -356,12 +356,12 @@ export function handleProfileTool(
     case "quillby_set_context": {
       return (async () => {
         const activeStorage = await resolveStorage();
-        const { context } = args as { context: Record<string, unknown> };
-        const parsed = UserContextSchema.parse(context);
-        await activeStorage.saveContext(parsed);
+        const context = UserContextSchema.parse((args as { context: unknown }).context);
+        await activeStorage.saveContext(context);
+        const setCtxWs = await activeStorage.getCurrentWorkspace();
         return {
-          content: [{ type: "text" as const, text: "User context saved." }],
-          structuredContent: { saved: true },
+          content: [{ type: "text" as const, text: `Context saved for workspace "${setCtxWs.name}". Role: ${context.role}. Topics: ${context.topics.join(", ")}. Platforms: ${context.platforms.join(", ")}.` }],
+          structuredContent: { saved: true, workspaceId: setCtxWs.id, role: context.role, topics: context.topics, platforms: context.platforms },
         };
       })();
     }
@@ -369,10 +369,14 @@ export function handleProfileTool(
     case "quillby_get_context": {
       return (async () => {
         const activeStorage = await resolveStorage();
-        const ctxData = await activeStorage.loadContext();
+        if (!await activeStorage.contextExists()) {
+          return { content: [{ type: "text" as const, text: "No context saved for this workspace yet. Start by setting up Quillby for it." }], structuredContent: { error: "no_context" } };
+        }
+        const ctxData = (await activeStorage.loadContext()) as Record<string, unknown>;
+        const getCtxWs = await activeStorage.getCurrentWorkspace();
         return {
-          content: [{ type: "text" as const, text: JSON.stringify(ctxData, null, 2) }],
-          structuredContent: ctxData ?? undefined,
+          content: [{ type: "text" as const, text: JSON.stringify({ workspace: getCtxWs, context: ctxData }, null, 2) }],
+          structuredContent: { workspace: getCtxWs, context: ctxData },
         };
       })();
     }

--- a/apps/mcp-server/src/mcp/tools/profile.ts
+++ b/apps/mcp-server/src/mcp/tools/profile.ts
@@ -1,0 +1,383 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { validateUrl, ElevenLabsAdapter } from "@quillby/providers";
+import { UserContextSchema } from "../../types.js";
+import { resolveElevenLabsApiKey } from "../../provider-config.js";
+import { SetCloneIdentityArgsSchema, CloneVoiceArgsSchema } from "../schemas.js";
+import type { ToolContext } from "./index.js";
+
+export const toolDefinitions: Partial<Tool>[] = [
+  {
+    name: "quillby_list_workspaces",
+    description: "List Quillby workspaces. Use one workspace per Claude Project, client, publication, or campaign.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "quillby_create_workspace",
+    description: "Create a workspace with isolated context, memories, feeds, and outputs.",
+    annotations: { destructiveHint: false },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        workspaceId: { type: "string" },
+        description: { type: "string" },
+        makeCurrent: { type: "boolean" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "quillby_select_workspace",
+    description: "Switch the active Quillby workspace.",
+    annotations: { destructiveHint: false, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: { workspaceId: { type: "string" } },
+      required: ["workspaceId"],
+    },
+  },
+  {
+    name: "quillby_get_workspace",
+    description: "Inspect the active workspace or a specific workspace.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: { workspaceId: { type: "string" } },
+    },
+  },
+  {
+    name: "quillby_set_clone_identity",
+    description: "Set workspace-level identity clone references and consent.",
+    annotations: { destructiveHint: false, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspaceId: { type: "string" },
+        faceReferenceImageUrl: { type: "string" },
+        voiceReferenceAudioUrl: { type: "string" },
+        cloneConsentGranted: { type: "boolean" },
+      },
+      required: ["cloneConsentGranted"],
+    },
+  },
+  {
+    name: "quillby_clone_voice",
+    description: "Create a persistent ElevenLabs voice clone.",
+    annotations: { destructiveHint: false, idempotentHint: false },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspaceId: { type: "string" },
+        name: { type: "string" },
+        overwrite: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "quillby_delete_voice_clone",
+    description: "Delete the persistent ElevenLabs voice clone.",
+    annotations: { destructiveHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: { workspaceId: { type: "string" } },
+    },
+  },
+  {
+    name: "quillby_set_context",
+    description: "Save the user content creator profile after onboarding.",
+    annotations: { destructiveHint: false, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspaceId: { type: "string" },
+        context: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            role: { type: "string" },
+            industry: { type: "string" },
+            topics: { type: "array", items: { type: "string" } },
+            voice: { type: "string" },
+            audienceDescription: { type: "string" },
+            contentGoals: { type: "array", items: { type: "string" } },
+            excludeTopics: { type: "array", items: { type: "string" } },
+            platforms: { type: "array", items: { type: "string" } },
+          },
+          required: ["role", "industry", "topics", "voice", "audienceDescription", "contentGoals", "platforms"],
+        },
+      },
+      required: ["context"],
+    },
+  },
+  {
+    name: "quillby_get_context",
+    description: "Load the saved user profile.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: { workspaceId: { type: "string" } },
+    },
+  },
+];
+
+export function handleProfileTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<{
+  content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}> {
+  const { storage } = ctx;
+
+  const resolveStorage = async () => {
+    const workspaceId = typeof args.workspaceId === "string" ? args.workspaceId : undefined;
+    if (!workspaceId) return storage;
+    return storage.withWorkspace(workspaceId);
+  };
+
+  switch (name) {
+    case "quillby_list_workspaces": {
+      return (async () => {
+        const currentWorkspaceId = await storage.getCurrentWorkspaceId();
+        const workspaces = (await storage.listWorkspaces()).map((workspace) => ({
+          ...workspace,
+          current: workspace.id === currentWorkspaceId,
+        }));
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ currentWorkspaceId, workspaces }, null, 2) }],
+          structuredContent: { currentWorkspaceId, workspaces },
+        };
+      })();
+    }
+
+    case "quillby_create_workspace": {
+      return (async () => {
+        const { name: workspaceName, workspaceId, description, makeCurrent } = args as {
+          name: string;
+          workspaceId?: string;
+          description?: string;
+          makeCurrent?: boolean;
+        };
+        const workspace = await storage.createWorkspace({
+          id: workspaceId,
+          name: workspaceName,
+          description,
+          makeCurrent: makeCurrent ?? true,
+        });
+        return {
+          content: [{ type: "text" as const, text: `Workspace "${workspace.name}" created with id "${workspace.id}".` }],
+          structuredContent: workspace,
+        };
+      })();
+    }
+
+    case "quillby_select_workspace": {
+      return (async () => {
+        const { workspaceId } = args as { workspaceId: string };
+        const workspace = await storage.setCurrentWorkspace(workspaceId);
+        return {
+          content: [{ type: "text" as const, text: `Current workspace set to "${workspace.name}" (${workspace.id}).` }],
+          structuredContent: workspace,
+        };
+      })();
+    }
+
+    case "quillby_get_workspace": {
+      return (async () => {
+        const activeStorage = await resolveStorage();
+        const workspace = await activeStorage.getCurrentWorkspace();
+        const [ctxData, mem, sources] = await Promise.all([
+          activeStorage.loadContext(),
+          activeStorage.loadTypedMemory(),
+          activeStorage.loadSources(),
+        ]);
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ workspace, current: true, context: ctxData, memory: mem, feedCount: sources.length }, null, 2),
+          }],
+          structuredContent: { workspace, current: true, context: ctxData, memory: mem, feedCount: sources.length },
+        };
+      })();
+    }
+
+    case "quillby_set_clone_identity": {
+      return (async () => {
+        const activeStorage = await resolveStorage();
+        const parsedIc = SetCloneIdentityArgsSchema.parse(args);
+        const { faceReferenceImageUrl, voiceReferenceAudioUrl, cloneConsentGranted } = parsedIc;
+
+        if (faceReferenceImageUrl !== undefined) {
+          try {
+            await validateUrl(faceReferenceImageUrl);
+          } catch (err) {
+            throw new Error(`faceReferenceImageUrl validation failed: ${err instanceof Error ? err.message : "invalid URL"}`);
+          }
+        }
+        if (voiceReferenceAudioUrl !== undefined) {
+          try {
+            await validateUrl(voiceReferenceAudioUrl);
+          } catch (err) {
+            throw new Error(`voiceReferenceAudioUrl validation failed: ${err instanceof Error ? err.message : "invalid URL"}`);
+          }
+        }
+
+        const workspace = await activeStorage.updateWorkspaceMetadata({
+          ...(faceReferenceImageUrl !== undefined && { faceReferenceImageUrl }),
+          ...(voiceReferenceAudioUrl !== undefined && { voiceReferenceAudioUrl }),
+          cloneConsentGranted,
+          cloneConsentAt: cloneConsentGranted ? new Date().toISOString() : undefined,
+        });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            workspaceId: workspace.id,
+            cloneConsentGranted: workspace.cloneConsentGranted,
+            faceReferenceImageUrl: workspace.faceReferenceImageUrl,
+            voiceReferenceAudioUrl: workspace.voiceReferenceAudioUrl,
+            cloneConsentAt: workspace.cloneConsentAt,
+          }, null, 2) }],
+          structuredContent: {
+            workspaceId: workspace.id,
+            cloneConsentGranted: workspace.cloneConsentGranted,
+            faceReferenceImageUrl: workspace.faceReferenceImageUrl,
+            voiceReferenceAudioUrl: workspace.voiceReferenceAudioUrl,
+            cloneConsentAt: workspace.cloneConsentAt,
+          },
+        };
+      })();
+    }
+
+    case "quillby_clone_voice": {
+      return (async () => {
+        const activeStorage = await resolveStorage();
+        const parsedCv = CloneVoiceArgsSchema.parse(args);
+        const { name: voiceName, overwrite } = parsedCv;
+        const workspace = await activeStorage.getCurrentWorkspace() as Record<string, unknown> & {
+          cloneConsentGranted?: boolean;
+          voiceReferenceAudioUrl?: string;
+          elevenlabsClonedVoiceId?: string;
+          name?: string;
+        };
+
+        if (!workspace.cloneConsentGranted) {
+          throw new Error("Clone consent must be granted before creating a voice clone. Call quillby_set_clone_identity first.");
+        }
+        if (!workspace.voiceReferenceAudioUrl) {
+          throw new Error("No voiceReferenceAudioUrl set. Call quillby_set_clone_identity with a voice sample URL first.");
+        }
+
+        const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode as "local" | "self-hosted" | "cloud");
+        if (!elevenLabsApiKey) {
+          throw new Error("ElevenLabs is not configured. Set QUILLBY_ELEVENLABS_API_KEY or configure the audio provider via quillby_set_provider.");
+        }
+
+        if (workspace.elevenlabsClonedVoiceId && !overwrite) {
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({
+              workspaceId: workspace.id,
+              elevenlabsClonedVoiceId: workspace.elevenlabsClonedVoiceId,
+              status: "already_cloned",
+            }, null, 2) }],
+            structuredContent: {
+              workspaceId: workspace.id,
+              elevenlabsClonedVoiceId: workspace.elevenlabsClonedVoiceId,
+              status: "already_cloned",
+            },
+          };
+        }
+
+        if (workspace.elevenlabsClonedVoiceId && overwrite) {
+          await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId)
+            .catch(() => process.stderr.write("[quillby] Non-fatal: could not delete old ElevenLabs voice clone\n"));
+        }
+
+        const cloneName = voiceName?.trim() || workspace.name || "Quillby Voice Clone";
+        const clonedVoiceId = await ElevenLabsAdapter.createVoiceClone(elevenLabsApiKey, workspace.voiceReferenceAudioUrl, cloneName);
+        const updated = await activeStorage.updateWorkspaceMetadata({ elevenlabsClonedVoiceId: clonedVoiceId });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            workspaceId: updated.id,
+            elevenlabsClonedVoiceId: updated.elevenlabsClonedVoiceId,
+            status: "cloned",
+          }, null, 2) }],
+          structuredContent: {
+            workspaceId: updated.id,
+            elevenlabsClonedVoiceId: updated.elevenlabsClonedVoiceId,
+            status: "cloned",
+          },
+        };
+      })();
+    }
+
+    case "quillby_delete_voice_clone": {
+      return (async () => {
+        const activeStorage = await resolveStorage();
+        const workspace = await activeStorage.getCurrentWorkspace() as Record<string, unknown> & {
+          elevenlabsClonedVoiceId?: string;
+          id?: string;
+        };
+
+        if (!workspace.elevenlabsClonedVoiceId) {
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ workspaceId: workspace.id, status: "no_clone" }, null, 2) }],
+            structuredContent: { workspaceId: workspace.id, status: "no_clone" },
+          };
+        }
+
+        const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode as "local" | "self-hosted" | "cloud");
+        if (elevenLabsApiKey) {
+          await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId)
+            .catch(() => process.stderr.write("[quillby] Non-fatal: ElevenLabs deleteVoiceClone failed in delete handler\n"));
+        }
+
+        await activeStorage.updateWorkspaceMetadata({ elevenlabsClonedVoiceId: "" });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ workspaceId: workspace.id, status: "deleted" }, null, 2) }],
+          structuredContent: { workspaceId: workspace.id, status: "deleted" },
+        };
+      })();
+    }
+
+    case "quillby_set_context": {
+      return (async () => {
+        const activeStorage = await resolveStorage();
+        const { context } = args as { context: Record<string, unknown> };
+        const parsed = UserContextSchema.parse(context);
+        await activeStorage.saveContext(parsed);
+        return {
+          content: [{ type: "text" as const, text: "User context saved." }],
+          structuredContent: { saved: true },
+        };
+      })();
+    }
+
+    case "quillby_get_context": {
+      return (async () => {
+        const activeStorage = await resolveStorage();
+        const ctxData = await activeStorage.loadContext();
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(ctxData, null, 2) }],
+          structuredContent: ctxData ?? undefined,
+        };
+      })();
+    }
+
+    default:
+      return Promise.reject(new Error(`Unknown tool: ${name}`));
+  }
+}


### PR DESCRIPTION

Extracts 9 workspace/profile tool handlers into src/mcp/tools/profile.ts with shared types in src/mcp/tools/index.ts.

server.ts: 3765 → 3433 lines (-332). All 403 tests pass, lint + typecheck clean.

## Changes
- src/mcp/tools/index.ts (NEW): ToolContext, ToolStorage, ToolResult types
- src/mcp/tools/profile.ts (NEW): 9 profile tool definitions + handler
- server.ts: removed -347 lines, replaced with imports + dispatch delegation
