### PR TITLE
refactor: extract feed tool handlers from server.ts into src/mcp/tools/feeds.ts

### DIFF
--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -82,6 +82,7 @@ import {
 import {
   toolDefinitions as profileToolDefinitions,
   handleProfileTool,
+  PROFILE_TOOL_NAMES,
 } from "./tools/profile.js";
 import {
   toolDefinitions as feedToolDefinitions,
@@ -864,12 +865,6 @@ async function handleToolCall(
       if (!workspaceId) return storage as WorkspaceStorage & JobStorage;
       return storage.withWorkspace(workspaceId) as Promise<WorkspaceStorage & JobStorage>;
     };
-
-    const PROFILE_TOOL_NAMES = new Set([
-      "list_workspaces", "create_workspace", "select_workspace",
-      "get_workspace", "set_clone_identity", "clone_voice",
-      "delete_voice_clone", "set_context", "get_context",
-    ]);
 
     if (PROFILE_TOOL_NAMES.has(name)) {
       return handleProfileTool(name, args, { server, storage, deploymentMode, providerRouter, sample: (prompt, maxTokens) => sample(server, prompt, maxTokens) });

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -22,7 +22,6 @@ import {
   ONBOARDING_PROMPT,
 } from "../agents/onboard.js";
 import { fetchArticles, preScoreArticles } from "../agents/harvest.js";
-import { getGoogleNewsFeeds, getMediumTagFeeds, getFeedlyFeeds } from "../agents/seeds.js";
 import { PLATFORM_GUIDES } from "../agents/compose.js";
 import { enrichArticle } from "../extractors/content.js";
 import { getHostedUserStorage, storage, type WorkspaceStorage, type JobStorage } from "../storage.js";
@@ -84,6 +83,11 @@ import {
   toolDefinitions as profileToolDefinitions,
   handleProfileTool,
 } from "./tools/profile.js";
+import {
+  toolDefinitions as feedToolDefinitions,
+  handleFeedTool,
+  FEED_TOOL_NAMES,
+} from "./tools/feeds.js";
 import type { PlanStorage, SessionStore } from "@quillby/workspace";
 import {
   buildDirectAdaptersFromConfig,
@@ -232,74 +236,7 @@ const TOOLS: Tool[] = [
   },
 
   ...profileToolDefinitions,
-
-  // ── Feeds ─────────────────────────────────────────────────────────────────
-  {
-    name: "discover_feeds",
-    description:
-      "Discover and save content sources for the user's topics. Adds: Google News RSS (real-time news, any language), Medium tag feeds (professional articles on any industry), Feedly curated publications, and Reddit communities (reddit://r/<subreddit>) via Sampling. Works for any niche: healthcare, law, fashion, construction, farming, finance, etc.",
-    annotations: { idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        topics: {
-          type: "array",
-          items: { type: "string" },
-          description: "Override topics. Defaults to saved user context topics.",
-        },
-        locale: {
-          type: "string",
-          description: "BCP-47 language tag for Google News, e.g. \"en-US\", \"pt-BR\", \"fr-FR\". Defaults to en-US.",
-        },
-        country: {
-          type: "string",
-          description: "ISO 3166-1 country code for Google News, e.g. \"US\", \"BR\", \"FR\". Defaults to US.",
-        },
-      },
-    },
-  },
-  {
-    name: "add_feeds",
-    description: "Add content sources manually. Accepts: standard RSS/Atom URLs, Medium tag feeds (https://medium.com/feed/tag/<topic>), Google News RSS URLs, and Reddit communities (reddit://r/<subreddit> or reddit://r/<subreddit>/top). Deduplicates automatically.",
-    annotations: { idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        urls: { type: "array", items: { type: "string" }, description: "Source URLs: RSS/Atom URLs, medium.com/feed/tag/*, reddit://r/name" },
-      },
-      required: ["urls"],
-    },
-  },
-  {
-    name: "list_feeds",
-    description: "List all configured RSS feed URLs.",
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        workspaceId: { type: "string", description: "Optional workspace override without changing global selection." },
-      },
-    },
-  },
-
-  // ── Fetch & Research ──────────────────────────────────────────────────────
-  {
-    name: "read_article",
-    description: "Fetch full text for a single article URL using Mozilla Readability. Use after fetch_articles (slim=true).",
-    annotations: { readOnlyHint: true, idempotentHint: true },
-    outputSchema: { type: "object" as const },
-    inputSchema: {
-      type: "object",
-      properties: {
-        url: { type: "string", description: "Article URL to fetch" },
-        title: { type: "string", description: "Article title (improves extraction)" },
-      },
-      required: ["url"],
-    },
-  },
+  ...feedToolDefinitions,
 
   // ── Daily Brief (two-pass Sampling pipeline) ──────────────────────────────
   {
@@ -935,7 +872,11 @@ async function handleToolCall(
     ]);
 
     if (PROFILE_TOOL_NAMES.has(name)) {
-      return handleProfileTool(name, args, { server, storage, deploymentMode, providerRouter });
+      return handleProfileTool(name, args, { server, storage, deploymentMode, providerRouter, sample: (prompt, maxTokens) => sample(server, prompt, maxTokens) });
+    }
+
+    if (FEED_TOOL_NAMES.has(name)) {
+      return handleFeedTool(name, args, { server, storage, deploymentMode, providerRouter, sample: (prompt, maxTokens) => sample(server, prompt, maxTokens) });
     }
 
     switch (name) {
@@ -1062,93 +1003,6 @@ async function handleToolCall(
           content: [{ type: "text" as const, text: JSON.stringify({ workspace: getCtxWs, context: ctxData }, null, 2) }],
           structuredContent: { workspace: getCtxWs, context: ctxData },
         };
-      }
-
-      case "add_feeds": {
-        const { urls } = args as { urls: string[] };
-        const result = await storage.appendSources(urls);
-        const totalAfterAdd = (await storage.loadSources()).length;
-        return {
-          content: [{ type: "text" as const, text: `Added ${result.added} feed(s). Skipped ${result.skipped} duplicate(s). Total: ${totalAfterAdd}. Quillby is ready to open or refresh the workspace Briefing.` }],
-          structuredContent: { added: result.added, skipped: result.skipped, total: totalAfterAdd },
-        };
-      }
-
-      case "discover_feeds": {
-        const ctxExists = await storage.contextExists();
-        const ctx = ctxExists ? await storage.loadContext() : null;
-        const { topics: topicOverride, locale = "en-US", country = "US" } = args as { topics?: string[]; locale?: string; country?: string };
-        const topics: string[] = topicOverride?.length ? topicOverride : (ctx?.topics ?? []);
-        if (topics.length === 0) {
-          return { content: [{ type: "text" as const, text: "No topics are saved for this workspace yet. Update the Quillby setup first." }], structuredContent: { error: "no_topics" } };
-        }
-        const googleUrls = getGoogleNewsFeeds(topics, locale, country);
-        const mediumUrls = getMediumTagFeeds(topics);
-        const feedlyUrls = await getFeedlyFeeds(topics, 3);
-        const samplingAvailable = !!(server.server.getClientCapabilities()?.sampling);
-        let samplingUrls: string[] = [];
-        if (samplingAvailable) {
-          const samplingPrompt = `The user is a content creator covering these topics: ${topics.join(", ")}.
-
-Suggest niche content sources that broad news feeds would miss. For each suggestion:
-- Reddit communities relevant to these topics: use the format reddit://r/<subreddit> (e.g. reddit://r/smallbusiness, reddit://r/medicine, reddit://r/farming, reddit://r/law)
-- Niche industry association blogs, trade publication RSS feeds, or specialist Substack feeds: use standard https:// URLs
-
-Pick communities and publications that match the industry, not tech/startup defaults. A clothing boutique owner needs fashion/retail communities. A health professional needs medical/wellness sources. A lawyer needs legal industry feeds.
-
-Return ONLY a JSON array of strings. 10 items max. No explanation.`;
-          const raw = await sample(server, samplingPrompt, 600);
-          if (raw) {
-            try {
-              const match = raw.match(/\[.*\]/s);
-              if (match) {
-                const parsed = JSON.parse(match[0]) as unknown[];
-                samplingUrls = parsed.filter(
-                  (u): u is string =>
-                    typeof u === "string" &&
-                    (u.startsWith("http") || u.startsWith("reddit://"))
-                );
-              }
-            } catch (e) {
-              process.stderr.write(`[quillby] Non-fatal: Sampling response parse failed in discover_feeds: ${e}\n`);
-            }
-          }
-        }
-        const allUrls = [...new Set([...googleUrls, ...mediumUrls, ...feedlyUrls, ...samplingUrls])];
-        const result = await storage.appendSources(allUrls);
-        const discoverResult = {
-          topics,
-          googleNewsFeeds: googleUrls.length,
-          mediumTagFeeds: mediumUrls.length,
-          feedlyFeeds: feedlyUrls.length,
-          samplingFeeds: samplingUrls.length,
-          added: result.added,
-          skipped: result.skipped,
-          totalFeeds: (await storage.loadSources()).length,
-        };
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(discoverResult, null, 2) }],
-          structuredContent: discoverResult,
-        };
-      }
-
-      case "list_feeds": {
-        const activeStorage = await resolveStorage();
-        const sources = await activeStorage.loadSources();
-        const listFeedsResult = { count: sources.length, feeds: sources };
-        return {
-          content: [{ type: "text" as const, text: sources.length ? JSON.stringify(listFeedsResult, null, 2) : "No feeds configured. Use add_feeds." }],
-          structuredContent: listFeedsResult,
-        };
-      }
-
-      case "read_article": {
-        const { url, title = "" } = args as { url: string; title?: string };
-        const content = await enrichArticle(url, title);
-        if (!content) {
-          return { content: [{ type: "text" as const, text: "Could not retrieve article content (paywalled or fetch failed)." }], structuredContent: { content: null, error: "fetch_failed" } };
-        }
-        return { content: [{ type: "text" as const, text: content }], structuredContent: { content } };
       }
 
       case "open_briefing": {

--- a/apps/mcp-server/src/mcp/tools/feeds.ts
+++ b/apps/mcp-server/src/mcp/tools/feeds.ts
@@ -1,0 +1,177 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { getGoogleNewsFeeds, getMediumTagFeeds, getFeedlyFeeds } from "../../agents/seeds.js";
+import { enrichArticle } from "../../extractors/content.js";
+import type { ToolContext, ToolStorage } from "./index.js";
+
+const FEED_TOOL_NAMES = new Set([
+  "add_feeds", "discover_feeds", "list_feeds", "read_article",
+]);
+
+export { FEED_TOOL_NAMES };
+
+export const toolDefinitions: Tool[] = [
+  {
+    name: "discover_feeds",
+    description:
+      "Discover and save content sources for the user's topics. Adds: Google News RSS (real-time news, any language), Medium tag feeds (professional articles on any industry), Feedly curated publications, and Reddit communities (reddit://r/<subreddit>) via Sampling. Works for any niche: healthcare, law, fashion, construction, farming, finance, etc.",
+    annotations: { idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        topics: { type: "array", items: { type: "string" }, description: "Override topics. Defaults to saved user context topics." },
+        locale: { type: "string", description: "BCP-47 language tag for Google News, e.g. \"en-US\", \"pt-BR\", \"fr-FR\". Defaults to en-US." },
+        country: { type: "string", description: "ISO 3166-1 country code for Google News, e.g. \"US\", \"BR\", \"FR\". Defaults to US." },
+      },
+    },
+  },
+  {
+    name: "add_feeds",
+    description: "Add content sources manually. Accepts: standard RSS/Atom URLs, Medium tag feeds (https://medium.com/feed/tag/<topic>), Google News RSS URLs, and Reddit communities (reddit://r/<subreddit> or reddit://r/<subreddit>/top). Deduplicates automatically.",
+    annotations: { idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: { urls: { type: "array", items: { type: "string" }, description: "Source URLs: RSS/Atom URLs, medium.com/feed/tag/*, reddit://r/name" } },
+      required: ["urls"],
+    },
+  },
+  {
+    name: "list_feeds",
+    description: "List all configured RSS feed URLs.",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: { workspaceId: { type: "string", description: "Optional workspace override without changing global selection." } },
+    },
+  },
+  {
+    name: "read_article",
+    description: "Fetch full text for a single article URL using Mozilla Readability. Use after fetch_articles (slim=true).",
+    annotations: { readOnlyHint: true, idempotentHint: true },
+    outputSchema: { type: "object" as const },
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "Article URL to fetch" },
+        title: { type: "string", description: "Article title (improves extraction)" },
+      },
+      required: ["url"],
+    },
+  },
+];
+
+async function resolveStorage(storage: ToolStorage, args: Record<string, unknown>): Promise<ToolStorage> {
+  const workspaceId = typeof args.workspaceId === "string" ? args.workspaceId : undefined;
+  if (!workspaceId) return storage;
+  return storage.withWorkspace(workspaceId);
+}
+
+export function handleFeedTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<{ content: { type: "text"; text: string }[]; structuredContent?: Record<string, unknown>; isError?: boolean }> {
+  const { storage } = ctx;
+
+  switch (name) {
+    case "add_feeds": {
+      return (async () => {
+        const { urls } = args as { urls: string[] };
+        const result = await storage.appendSources(urls);
+        const totalAfterAdd = (await storage.loadSources()).length;
+        return {
+          content: [{ type: "text" as const, text: `Added ${result.added} feed(s). Skipped ${result.skipped} duplicate(s). Total: ${totalAfterAdd}. Quillby is ready to open or refresh the workspace Briefing.` }],
+          structuredContent: { added: result.added, skipped: result.skipped, total: totalAfterAdd },
+        };
+      })();
+    }
+
+    case "discover_feeds": {
+      return (async () => {
+        const ctxExists = await storage.contextExists();
+        const savedCtx = ctxExists ? await storage.loadContext() : null;
+        const { topics: topicOverride, locale = "en-US", country = "US" } = args as { topics?: string[]; locale?: string; country?: string };
+        const topics: string[] = topicOverride?.length ? topicOverride : (savedCtx && typeof savedCtx === "object" && "topics" in savedCtx ? (savedCtx as Record<string, unknown>).topics as string[] : []);
+        if (topics.length === 0) {
+          return { content: [{ type: "text" as const, text: "No topics are saved for this workspace yet. Update the Quillby setup first." }], structuredContent: { error: "no_topics" } };
+        }
+        const googleUrls = getGoogleNewsFeeds(topics, locale, country);
+        const mediumUrls = getMediumTagFeeds(topics);
+        const feedlyUrls = await getFeedlyFeeds(topics, 3);
+        const samplingAvailable = !!(ctx.server.server.getClientCapabilities()?.sampling);
+        let samplingUrls: string[] = [];
+        if (samplingAvailable) {
+          const samplingPrompt = `The user is a content creator covering these topics: ${topics.join(", ")}.
+
+Suggest niche content sources that broad news feeds would miss. For each suggestion:
+- Reddit communities relevant to these topics: use the format reddit://r/<subreddit> (e.g. reddit://r/smallbusiness, reddit://r/medicine, reddit://r/farming, reddit://r/law)
+- Niche industry association blogs, trade publication RSS feeds, or specialist Substack feeds: use standard https:// URLs
+
+Pick communities and publications that match the industry, not tech/startup defaults. A clothing boutique owner needs fashion/retail communities. A health professional needs medical/wellness sources. A lawyer needs legal industry feeds.
+
+Return ONLY a JSON array of strings. 10 items max. No explanation.`;
+          const raw = await ctx.sample(samplingPrompt, 600);
+          if (raw) {
+            try {
+              const match = raw.match(/\[.*\]/s);
+              if (match) {
+                const parsed = JSON.parse(match[0]) as unknown[];
+                samplingUrls = parsed.filter(
+                  (u): u is string =>
+                    typeof u === "string" &&
+                    (u.startsWith("http") || u.startsWith("reddit://"))
+                );
+              }
+            } catch (e) {
+              process.stderr.write(`[quillby] Non-fatal: Sampling response parse failed in discover_feeds: ${e}\n`);
+            }
+          }
+        }
+        const allUrls = [...new Set([...googleUrls, ...mediumUrls, ...feedlyUrls, ...samplingUrls])];
+        const result = await storage.appendSources(allUrls);
+        const discoverResult = {
+          topics,
+          googleNewsFeeds: googleUrls.length,
+          mediumTagFeeds: mediumUrls.length,
+          feedlyFeeds: feedlyUrls.length,
+          samplingFeeds: samplingUrls.length,
+          added: result.added,
+          skipped: result.skipped,
+          totalFeeds: (await storage.loadSources()).length,
+        };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(discoverResult, null, 2) }],
+          structuredContent: discoverResult,
+        };
+      })();
+    }
+
+    case "list_feeds": {
+      return (async () => {
+        const activeStorage = await resolveStorage(storage, args);
+        const sources = await activeStorage.loadSources();
+        const listFeedsResult = { count: sources.length, feeds: sources };
+        return {
+          content: [{ type: "text" as const, text: sources.length ? JSON.stringify(listFeedsResult, null, 2) : "No feeds configured. Use add_feeds." }],
+          structuredContent: listFeedsResult,
+        };
+      })();
+    }
+
+    case "read_article": {
+      return (async () => {
+        const { url, title = "" } = args as { url: string; title?: string };
+        const content = await enrichArticle(url, title);
+        if (!content) {
+          return { content: [{ type: "text" as const, text: "Could not retrieve article content (paywalled or fetch failed)." }], structuredContent: { content: null, error: "fetch_failed" } };
+        }
+        return { content: [{ type: "text" as const, text: content }], structuredContent: { content } };
+      })();
+    }
+
+    default:
+      return Promise.reject(new Error(`Unknown tool: ${name}`));
+  }
+}

--- a/apps/mcp-server/src/mcp/tools/feeds.ts
+++ b/apps/mcp-server/src/mcp/tools/feeds.ts
@@ -3,6 +3,13 @@ import { getGoogleNewsFeeds, getMediumTagFeeds, getFeedlyFeeds } from "../../age
 import { enrichArticle } from "../../extractors/content.js";
 import type { ToolContext, ToolStorage } from "./index.js";
 
+function extractContextTopics(ctx: Record<string, unknown> | null): string[] {
+  if (!ctx) return [];
+  const topics = ctx.topics;
+  if (Array.isArray(topics) && topics.every((t): t is string => typeof t === "string")) return topics;
+  return [];
+}
+
 const FEED_TOOL_NAMES = new Set([
   "add_feeds", "discover_feeds", "list_feeds", "read_article",
 ]);
@@ -93,7 +100,7 @@ export function handleFeedTool(
         const ctxExists = await storage.contextExists();
         const savedCtx = ctxExists ? await storage.loadContext() : null;
         const { topics: topicOverride, locale = "en-US", country = "US" } = args as { topics?: string[]; locale?: string; country?: string };
-        const topics: string[] = topicOverride?.length ? topicOverride : (savedCtx && typeof savedCtx === "object" && "topics" in savedCtx ? (savedCtx as Record<string, unknown>).topics as string[] : []);
+        const topics: string[] = topicOverride?.length ? topicOverride : extractContextTopics(savedCtx);
         if (topics.length === 0) {
           return { content: [{ type: "text" as const, text: "No topics are saved for this workspace yet. Update the Quillby setup first." }], structuredContent: { error: "no_topics" } };
         }

--- a/apps/mcp-server/src/mcp/tools/index.ts
+++ b/apps/mcp-server/src/mcp/tools/index.ts
@@ -21,7 +21,7 @@ export interface ToolStorage {
   loadContext(): Promise<Record<string, unknown> | null>;
   saveContext(ctx: Record<string, unknown>): Promise<void>;
   loadTypedMemory(): Promise<Record<string, unknown> | null>;
-  loadSources(): Promise<unknown[]>;
+  loadSources(): Promise<string[]>;
   appendSources(urls: string[]): Promise<{ added: number; skipped: number }>;
   updateWorkspaceMetadata(meta: Record<string, unknown>): Promise<{ id: string; [key: string]: unknown }>;
   latestHarvestExists(): Promise<boolean>;

--- a/apps/mcp-server/src/mcp/tools/index.ts
+++ b/apps/mcp-server/src/mcp/tools/index.ts
@@ -1,5 +1,14 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ProviderRouter } from "@quillby/providers";
+import type { DeploymentMode } from "@quillby/config";
+
+export interface ToolContext {
+  server: McpServer;
+  storage: ToolStorage;
+  deploymentMode: DeploymentMode;
+  providerRouter: ProviderRouter;
+  sample: (prompt: string, maxTokens?: number) => Promise<string | null>;
+}
 
 export interface ToolStorage {
   getCurrentWorkspaceId(): Promise<string>;
@@ -13,20 +22,14 @@ export interface ToolStorage {
   saveContext(ctx: Record<string, unknown>): Promise<void>;
   loadTypedMemory(): Promise<Record<string, unknown> | null>;
   loadSources(): Promise<unknown[]>;
+  appendSources(urls: string[]): Promise<{ added: number; skipped: number }>;
   updateWorkspaceMetadata(meta: Record<string, unknown>): Promise<{ id: string; [key: string]: unknown }>;
-}
-
-import type { DeploymentMode } from "@quillby/config";
-
-export interface ToolContext {
-  server: McpServer;
-  storage: ToolStorage;
-  deploymentMode: DeploymentMode;
-  providerRouter: ProviderRouter;
+  latestHarvestExists(): Promise<boolean>;
+  loadLatestHarvest(): Promise<Record<string, unknown> | null>;
 }
 
 export type ToolResult = {
-  content: { type: "text"; text: string; annotations?: Record<string, unknown>; _meta?: Record<string, unknown> }[];
+  content: { type: "text"; text: string }[];
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };

--- a/apps/mcp-server/src/mcp/tools/profile.ts
+++ b/apps/mcp-server/src/mcp/tools/profile.ts
@@ -130,6 +130,8 @@ export const toolDefinitions: Tool[] = [
   },
 ];
 
+export const PROFILE_TOOL_NAMES = new Set(toolDefinitions.map((t) => t.name));
+
 export function handleProfileTool(
   name: string,
   args: Record<string, unknown>,


### PR DESCRIPTION

Extracts 4 feed/research tools into src/mcp/tools/feeds.ts. Adds `sample` callback to ToolContext.

## Changes
- src/mcp/tools/feeds.ts (NEW): 4 tool definitions + handler (add_feeds, discover_feeds, list_feeds, read_article)
- tools/index.ts: added sample, appendSources, latestHarvestExists, fixed loadSources type
- server.ts: -167 lines, imports dispatch from feeds.ts
- profile.ts: PROFILE_TOOL_NAMES now exported (consistent with FEED_TOOL_NAMES)

server.ts: 3765 → 3286 lines (-479 total across both extractions). 403 tests pass, lint + typecheck clean.
