### PR TITLE
feat(mcp-server): REQ-000234 operational hardening — rate limiting, logging, sessions, email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ BETTER_AUTH_SECRET=
 # Default per-key API rate limit (requests per minute)
 QUILLBY_RATE_LIMIT=60
 
+# Per-IP rate limiting for unauthenticated routes (requests per window)
+QUILLBY_IP_RATE_LIMIT=60
+# Rate limit window in milliseconds (default: 60000 = 1 minute)
+QUILLBY_IP_RATE_LIMIT_WINDOW_MS=60000
+
 # ── provider keys (optional — can also be configured via Settings UI) ──
 # QUILLBY_REPLICATE_API_TOKEN=     # Single token unlocks image+audio+video via Replicate
 # QUILLBY_REPLICATE_IMAGE_MODEL=   # Default: black-forest-labs/flux-2-pro

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,19 @@ QUILLBY_IP_RATE_LIMIT=60
 # Rate limit window in milliseconds (default: 60000 = 1 minute)
 QUILLBY_IP_RATE_LIMIT_WINDOW_MS=60000
 
+# App session TTL in milliseconds (default: 604800000 = 7 days)
+QUILLBY_APP_SESSION_TTL_MS=604800000
+
+# MCP session TTL in milliseconds (default: 86400000 = 24 hours)
+QUILLBY_MCP_SESSION_TTL_MS=86400000
+
+# ── SMTP (required for email verification and password reset) ──
+# QUILLBY_SMTP_HOST=smtp.example.com
+# QUILLBY_SMTP_PORT=587
+# QUILLBY_SMTP_USER=quillby@example.com
+# QUILLBY_SMTP_PASS=
+# QUILLBY_SMTP_FROM="Quillby <noreply@example.com>"
+
 # ── provider keys (optional — can also be configured via Settings UI) ──
 # QUILLBY_REPLICATE_API_TOKEN=     # Single token unlocks image+audio+video via Replicate
 # QUILLBY_REPLICATE_IMAGE_MODEL=   # Default: black-forest-labs/flux-2-pro

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -77,11 +77,13 @@
     "kysely": "^0.28.8",
     "linkedom": "^0.18.12",
     "nanostores": "^1.1.0",
+    "nodemailer": "^8.0.9",
     "rss-parser": "^3.13.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
+    "@types/nodemailer": "^8.0.0",
     "@vitest/coverage-v8": "^4.1.7",
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.7.2",

--- a/apps/mcp-server/src/auth.ts
+++ b/apps/mcp-server/src/auth.ts
@@ -3,6 +3,8 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { apiKey } from "@better-auth/api-key";
 import { db } from "./db.js";
 import * as schema from "./db/schema.js";
+import { sendVerificationEmail, sendResetPasswordEmail } from "./email.js";
+import { slog } from "./logger.js";
 
 // QUILLBY_RATE_LIMIT sets the default max requests per minute for new API keys.
 // Individual keys can override this at creation time via manage-keys.ts.
@@ -46,9 +48,16 @@ export const auth = betterAuth({
     },
   }),
 
-  // Email + password is the primary way to register users who then generate
-  // API keys. Social providers can be added here in a future version.
-  emailAndPassword: { enabled: true },
+  emailAndPassword: {
+    enabled: true,
+    sendEmailVerification: true,
+    async sendVerificationEmail(data: { user: { email: string; name?: string }; url: string }) {
+      await sendVerificationEmail(data.user, data.url);
+    },
+    async sendResetPassword(data: { user: { email: string; name?: string }; url: string }) {
+      await sendResetPasswordEmail(data.user, data.url);
+    },
+  },
 
   // Allow the app origin (e.g. http://localhost:5173 in dev) to make
   // credentialed auth requests without Better Auth's CSRF 403 rejection.
@@ -58,3 +67,9 @@ export const auth = betterAuth({
     apiKeyPlugin,
   ],
 });
+
+if (process.env.QUILLBY_SMTP_HOST) {
+  slog("info", "SMTP configured — email verification and password reset enabled");
+} else {
+  slog("info", "SMTP not configured — email verification and password reset will log URLs only");
+}

--- a/apps/mcp-server/src/email.ts
+++ b/apps/mcp-server/src/email.ts
@@ -1,0 +1,62 @@
+import nodemailer from "nodemailer";
+import { slog } from "./logger.js";
+
+interface EmailUser {
+  email: string;
+  name?: string;
+}
+
+function getTransporter(): nodemailer.Transporter | null {
+  const host = process.env.QUILLBY_SMTP_HOST;
+  const port = parseInt(process.env.QUILLBY_SMTP_PORT ?? "587", 10);
+  const user = process.env.QUILLBY_SMTP_USER;
+  const pass = process.env.QUILLBY_SMTP_PASS;
+  const from = process.env.QUILLBY_SMTP_FROM;
+
+  if (!host || !user || !pass || !from) {
+    return null;
+  }
+
+  return nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: { user, pass },
+  });
+}
+
+const FROM = process.env.QUILLBY_SMTP_FROM ?? "noreply@quillby.app";
+
+export async function sendVerificationEmail(user: EmailUser, url: string): Promise<void> {
+  const transporter = getTransporter();
+  if (!transporter) {
+    slog("warn", "SMTP not configured — verification email not sent", { email: user.email, url });
+    return;
+  }
+
+  await transporter.sendMail({
+    from: FROM,
+    to: user.email,
+    subject: "Verify your Quillby account",
+    text: `Welcome to Quillby!\n\nClick the link below to verify your email address:\n${url}`,
+    html: `<p>Welcome to Quillby!</p><p>Click the link below to verify your email address:</p><p><a href="${url}">${url}</a></p>`,
+  });
+  slog("info", "Verification email sent", { email: user.email });
+}
+
+export async function sendResetPasswordEmail(user: EmailUser, url: string): Promise<void> {
+  const transporter = getTransporter();
+  if (!transporter) {
+    slog("warn", "SMTP not configured — password reset email not sent", { email: user.email, url });
+    return;
+  }
+
+  await transporter.sendMail({
+    from: FROM,
+    to: user.email,
+    subject: "Reset your Quillby password",
+    text: `You requested a password reset.\n\nClick the link below to reset your password:\n${url}\n\nIf you didn't request this, you can safely ignore this email.`,
+    html: `<p>You requested a password reset.</p><p>Click the link below to reset your password:</p><p><a href="${url}">${url}</a></p><p>If you didn't request this, you can safely ignore this email.</p>`,
+  });
+  slog("info", "Password reset email sent", { email: user.email });
+}

--- a/apps/mcp-server/src/email.ts
+++ b/apps/mcp-server/src/email.ts
@@ -6,7 +6,11 @@ interface EmailUser {
   name?: string;
 }
 
+let _transporter: nodemailer.Transporter | null | undefined;
+
 function getTransporter(): nodemailer.Transporter | null {
+  if (_transporter !== undefined) return _transporter;
+
   const host = process.env.QUILLBY_SMTP_HOST;
   const port = parseInt(process.env.QUILLBY_SMTP_PORT ?? "587", 10);
   const user = process.env.QUILLBY_SMTP_USER;
@@ -14,15 +18,17 @@ function getTransporter(): nodemailer.Transporter | null {
   const from = process.env.QUILLBY_SMTP_FROM;
 
   if (!host || !user || !pass || !from) {
+    _transporter = null;
     return null;
   }
 
-  return nodemailer.createTransport({
+  _transporter = nodemailer.createTransport({
     host,
     port,
     secure: port === 465,
     auth: { user, pass },
   });
+  return _transporter;
 }
 
 const FROM = process.env.QUILLBY_SMTP_FROM ?? "noreply@quillby.app";
@@ -34,14 +40,18 @@ export async function sendVerificationEmail(user: EmailUser, url: string): Promi
     return;
   }
 
-  await transporter.sendMail({
-    from: FROM,
-    to: user.email,
-    subject: "Verify your Quillby account",
-    text: `Welcome to Quillby!\n\nClick the link below to verify your email address:\n${url}`,
-    html: `<p>Welcome to Quillby!</p><p>Click the link below to verify your email address:</p><p><a href="${url}">${url}</a></p>`,
-  });
-  slog("info", "Verification email sent", { email: user.email });
+  try {
+    await transporter.sendMail({
+      from: FROM,
+      to: user.email,
+      subject: "Verify your Quillby account",
+      text: `Welcome to Quillby!\n\nClick the link below to verify your email address:\n${url}`,
+      html: `<p>Welcome to Quillby!</p><p>Click the link below to verify your email address:</p><p><a href="${url}">${url}</a></p>`,
+    });
+    slog("info", "Verification email sent", { email: user.email });
+  } catch (err) {
+    slog("error", "Failed to send verification email", { email: user.email, error: String(err) });
+  }
 }
 
 export async function sendResetPasswordEmail(user: EmailUser, url: string): Promise<void> {
@@ -51,12 +61,16 @@ export async function sendResetPasswordEmail(user: EmailUser, url: string): Prom
     return;
   }
 
-  await transporter.sendMail({
-    from: FROM,
-    to: user.email,
-    subject: "Reset your Quillby password",
-    text: `You requested a password reset.\n\nClick the link below to reset your password:\n${url}\n\nIf you didn't request this, you can safely ignore this email.`,
-    html: `<p>You requested a password reset.</p><p>Click the link below to reset your password:</p><p><a href="${url}">${url}</a></p><p>If you didn't request this, you can safely ignore this email.</p>`,
-  });
-  slog("info", "Password reset email sent", { email: user.email });
+  try {
+    await transporter.sendMail({
+      from: FROM,
+      to: user.email,
+      subject: "Reset your Quillby password",
+      text: `You requested a password reset.\n\nClick the link below to reset your password:\n${url}\n\nIf you didn't request this, you can safely ignore this email.`,
+      html: `<p>You requested a password reset.</p><p>Click the link below to reset your password:</p><p><a href="${url}">${url}</a></p><p>If you didn't request this, you can safely ignore this email.</p>`,
+    });
+    slog("info", "Password reset email sent", { email: user.email });
+  } catch (err) {
+    slog("error", "Failed to send password reset email", { email: user.email, error: String(err) });
+  }
 }

--- a/apps/mcp-server/src/logger.ts
+++ b/apps/mcp-server/src/logger.ts
@@ -1,9 +1,15 @@
 export type LogLevel = "info" | "warn" | "error" | "fatal";
 
 export function slog(level: LogLevel, msg: string, extra?: Record<string, unknown>): void {
-  process.stderr.write(
-    JSON.stringify({ ts: new Date().toISOString(), level, msg, ...extra }) + "\n",
-  );
+  try {
+    process.stderr.write(
+      JSON.stringify({ ts: new Date().toISOString(), level, msg, ...extra }) + "\n",
+    );
+  } catch {
+    process.stderr.write(
+      JSON.stringify({ ts: new Date().toISOString(), level, msg, _logError: "serialization failed" }) + "\n",
+    );
+  }
 }
 
 export function logInfo(msg: string, extra?: Record<string, unknown>): void {

--- a/apps/mcp-server/src/logger.ts
+++ b/apps/mcp-server/src/logger.ts
@@ -1,0 +1,23 @@
+export type LogLevel = "info" | "warn" | "error" | "fatal";
+
+export function slog(level: LogLevel, msg: string, extra?: Record<string, unknown>): void {
+  process.stderr.write(
+    JSON.stringify({ ts: new Date().toISOString(), level, msg, ...extra }) + "\n",
+  );
+}
+
+export function logInfo(msg: string, extra?: Record<string, unknown>): void {
+  slog("info", msg, extra);
+}
+
+export function logWarn(msg: string, extra?: Record<string, unknown>): void {
+  slog("warn", msg, extra);
+}
+
+export function logError(msg: string, extra?: Record<string, unknown>): void {
+  slog("error", msg, extra);
+}
+
+export function logFatal(msg: string, extra?: Record<string, unknown>): void {
+  slog("fatal", msg, extra);
+}

--- a/apps/mcp-server/src/mcp/middleware.ts
+++ b/apps/mcp-server/src/mcp/middleware.ts
@@ -1,0 +1,121 @@
+import type http from "node:http";
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === null) return fallback;
+  const value = parseInt(raw, 10);
+  if (Number.isNaN(value) || value < 1) return fallback;
+  return value;
+}
+
+const IP_RATE_LIMIT_MAX = parsePositiveInt(process.env.QUILLBY_IP_RATE_LIMIT, 60);
+const IP_RATE_LIMIT_WINDOW_MS = parsePositiveInt(process.env.QUILLBY_IP_RATE_LIMIT_WINDOW_MS, 60_000);
+
+const requestLog = new Map<string, number[]>();
+
+const CLEANUP_INTERVAL = Math.max(IP_RATE_LIMIT_WINDOW_MS, 60_000);
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+function ensureCleanupTimer(): void {
+  if (cleanupTimer) return;
+  cleanupTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [ip, timestamps] of requestLog) {
+      const recent = timestamps.filter((t) => now - t < IP_RATE_LIMIT_WINDOW_MS);
+      if (recent.length === 0) {
+        requestLog.delete(ip);
+      } else {
+        requestLog.set(ip, recent);
+      }
+    }
+  }, CLEANUP_INTERVAL);
+  cleanupTimer.unref();
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetMs: number;
+}
+
+export function checkRateLimit(ip: string): RateLimitResult {
+  ensureCleanupTimer();
+
+  const now = Date.now();
+  let timestamps = requestLog.get(ip);
+  if (!timestamps) {
+    timestamps = [];
+    requestLog.set(ip, timestamps);
+  }
+
+  const cutoff = now - IP_RATE_LIMIT_WINDOW_MS;
+  const recent = timestamps.filter((t) => t > cutoff);
+  requestLog.set(ip, recent);
+
+  if (recent.length >= IP_RATE_LIMIT_MAX) {
+    const oldest = recent[0]!;
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs: oldest + IP_RATE_LIMIT_WINDOW_MS - now,
+    };
+  }
+
+  const remaining = IP_RATE_LIMIT_MAX - recent.length - 1;
+  recent.push(now);
+  return {
+    allowed: true,
+    remaining,
+    resetMs: 0,
+  };
+}
+
+const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "DELETE", "OPTIONS"]);
+
+export function validateMethod(req: http.IncomingMessage): string | null {
+  if (!ALLOWED_METHODS.has(req.method ?? "")) {
+    return `Method ${req.method} not allowed`;
+  }
+  return null;
+}
+
+export function validateContentType(req: http.IncomingMessage): string | null {
+  const method = req.method ?? "";
+  if (method === "POST" || method === "PUT") {
+    const contentType = req.headers["content-type"] ?? "";
+    if (
+      !contentType.includes("application/json") &&
+      !contentType.includes("multipart/form-data")
+    ) {
+      return "Unsupported Content-Type: expected application/json or multipart/form-data";
+    }
+  }
+  return null;
+}
+
+const SECURITY_HEADERS: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-XSS-Protection": "0",
+};
+
+export function applySecurityHeaders(res: http.ServerResponse, baseUrl?: string): void {
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    res.setHeader(key, value);
+  }
+
+  if (baseUrl?.startsWith("https://")) {
+    res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
+}
+
+export function sendJsonError(
+  res: http.ServerResponse,
+  status: number,
+  message: string,
+  extra?: Record<string, unknown>,
+): void {
+  if (res.headersSent) return;
+  const body = JSON.stringify({ error: message, ...extra });
+  res.writeHead(status, { "Content-Type": "application/json" }).end(body);
+}

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import * as http from "node:http";
 import { randomUUID } from "node:crypto";
 import { toNodeHandler } from "better-auth/node";
+import { slog, logInfo, logWarn, logError, logFatal } from "../logger.js";
 import { auth } from "../auth.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -134,7 +135,7 @@ const deploymentMode = getDeploymentMode();
 refreshProviderRouter();
 
 for (const warning of verifyProviderEnv()) {
-  process.stderr.write(`[quillby] WARNING: ${warning}\n`);
+    logWarn("env", { warning });
 }
 
 const SERVER_INFO = { name: "quillby-mcp", version: "2.0.0" } as const;
@@ -143,12 +144,12 @@ function validateEnv(): void {
   const mode = getDeploymentMode();
   if (mode === "self-hosted" || mode === "cloud") {
     if (!process.env.BETTER_AUTH_SECRET?.trim()) {
-      process.stderr.write("[quillby] FATAL: BETTER_AUTH_SECRET is required in HTTP mode. Generate with: openssl rand -base64 32\n");
+      logFatal("BETTER_AUTH_SECRET is required in HTTP mode");
       process.exit(1);
     }
   }
   if (mode === "self-hosted" && !process.env.QUILLBY_PROVIDER_ENCRYPTION_KEY?.trim()) {
-    process.stderr.write("[quillby] WARNING: QUILLBY_PROVIDER_ENCRYPTION_KEY not set. Provider config via Settings UI will fail.\n");
+    logWarn("QUILLBY_PROVIDER_ENCRYPTION_KEY not set — provider config via Settings UI will fail");
   }
 }
 
@@ -183,7 +184,7 @@ function guessMimeType(modality: GenerationModality, outputRef: string, meta?: s
       if (parsed.mimeType) return parsed.mimeType;
     }
     } catch {
-    process.stderr.write("[quillby] Non-fatal: malformed meta JSON in guessMimeType\n");
+    logWarn("malformed meta JSON in guessMimeType");
   }
   const lower = outputRef.toLowerCase();
   if (lower.endsWith(".png")) return "image/png";
@@ -227,7 +228,7 @@ async function sample(server: McpServer, prompt: string, maxTokens = 4096): Prom
     if (result.content.type === "text") return result.content.text;
     return null;
   } catch (e) {
-    process.stderr.write(`[quillby] Non-fatal: MCP Sampling createMessage failed: ${e}\n`);
+    logWarn("MCP Sampling createMessage failed", { error: String(e) });
     return null;
   }
 }
@@ -863,7 +864,7 @@ async function handleToolCall(
   args: Record<string, unknown> = {}
 ) {
     const log = (message: string) => {
-    server.sendLoggingMessage({ level: "info", data: message }).catch(() => process.stderr.write("[quillby] Non-fatal: MCP logging message delivery failed\n"));
+    server.sendLoggingMessage({ level: "info", data: message }).catch(() => logWarn("MCP logging message delivery failed"));
   };
 
   try {
@@ -1145,7 +1146,7 @@ Return ONLY a JSON array of integers — the indices of the top ${topN} most rel
                 .slice(0, topN);
             }
           } catch (e) {
-            process.stderr.write(`[quillby] Non-fatal: Sampling score parse failed, falling back to keyword pre-scoring: ${e}\n`);
+            logWarn("Sampling score parse failed, falling back to keyword pre-scoring", { error: String(e) });
           }
         }
         if (topIndices.length === 0) {
@@ -2154,43 +2155,43 @@ async function runGenerationJob(
 async function runScheduledHarvest(): Promise<void> {
   const tag = "[quillby-schedule]";
   if (!await storage.contextExists()) {
-    process.stderr.write(`${tag} No profile saved — skipping.\n`);
+    logInfo("No profile saved — skipping harvest", { tag });
     return;
   }
   const ctx = (await storage.loadContext())!;
   const sources = await storage.loadSources();
   if (sources.length === 0) {
-    process.stderr.write(`${tag} No feeds configured — skipping.\n`);
+    logInfo("No feeds configured — skipping harvest", { tag });
     return;
   }
   const topN = parseInt(process.env.QUILLBY_SCHEDULE_TOP_N ?? "15", 10);
-  process.stderr.write(`${tag} Fetching articles from ${sources.length} feeds...\n`);
+  logInfo("Fetching articles", { tag, count: sources.length });
   try {
     const { articles, seenUrls } = await fetchArticles(
       sources,
       await storage.getSeenUrls(),
-      (msg) => process.stderr.write(`${tag} ${msg}\n`),
+      (msg) => logInfo(msg, { tag }),
       true,
     );
     await storage.saveSeenUrls(seenUrls);
     if (articles.length === 0) {
-      process.stderr.write(`${tag} No new articles.\n`);
+      logInfo("No new articles", { tag });
       return;
     }
     const top = preScoreArticles(articles, ctx.topics).slice(0, topN);
     const cards = top.map((a) =>
       CardInputSchema.parse({
         title: a.title ?? "Untitled",
-        source: (() => { try { return new URL(a.link).hostname; } catch { process.stderr.write("[quillby] Non-fatal: malformed URL in card source\n"); return a.link; } })(),
+        source: (() => { try { return new URL(a.link).hostname; } catch { logWarn("malformed URL in card source"); return a.link; } })(),
         link: a.link,
         thesis: a.snippet ?? a.title ?? "",
         trendTags: [],
       })
     );
     const outputDir = await storage.saveHarvestOutput(cards, seenUrls);
-    process.stderr.write(`${tag} Done. ${cards.length} card(s) saved to ${outputDir}.\n`);
+    logInfo("Harvest complete", { tag, cards: cards.length, outputDir });
   } catch (err) {
-    process.stderr.write(`${tag} Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    logError("Harvest failed", { tag, error: err instanceof Error ? err.message : String(err) });
   }
 }
 
@@ -2199,7 +2200,7 @@ function scheduleDaily(timeStr: string, fn: () => Promise<void>): void {
   const hour = parseInt(parts[0] ?? "", 10);
   const minute = parseInt(parts[1] ?? "0", 10);
   if (isNaN(hour) || isNaN(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-    process.stderr.write(`[quillby-schedule] Invalid QUILLBY_SCHEDULE "${timeStr}" — expected HH:MM. Scheduling disabled.\n`);
+    logError("Invalid QUILLBY_SCHEDULE format", { timeStr });
     return;
   }
   const msUntilNext = (): number => {
@@ -2211,7 +2212,7 @@ function scheduleDaily(timeStr: string, fn: () => Promise<void>): void {
   };
   const tick = (): void => {
     const delay = msUntilNext();
-    process.stderr.write(`[quillby-schedule] Next harvest at ${timeStr} (in ${Math.round(delay / 60000)} min).\n`);
+    logInfo("Next harvest scheduled", { time: timeStr, delayMin: Math.round(delay / 60000) });
     setTimeout(async () => { await fn(); tick(); }, delay).unref();
   };
   tick();
@@ -2222,14 +2223,7 @@ function scheduleDaily(timeStr: string, fn: () => Promise<void>): void {
 const TRANSPORT_MODE = process.env.QUILLBY_TRANSPORT ?? "stdio";
 validateEnv();
 
-// ---------------------------------------------------------------------------
-// Structured logger — used only in HTTP mode so it does not pollute stdio MCP.
-// Emits newline-delimited JSON to stderr.
-// ---------------------------------------------------------------------------
 
-function slog(level: "info" | "warn" | "error", msg: string, extra?: Record<string, unknown>): void {
-  process.stderr.write(JSON.stringify({ ts: new Date().toISOString(), level, msg, ...extra }) + "\n");
-}
 
 const HTTP_BODY_LIMIT = 1 * 1024 * 1024; // 1 MiB
 
@@ -2260,12 +2254,27 @@ if (TRANSPORT_MODE === "http") {
     ".txt":  "text/plain; charset=utf-8",
   };
 
+  const MCP_SESSION_TTL_MS = parseInt(process.env.QUILLBY_MCP_SESSION_TTL_MS ?? (24 * 60 * 60 * 1000).toString(), 10);
+
   // Map of sessionId → transport, so we can route GET/DELETE back to the right session.
   const sessions = new Map<string, {
     transport: StreamableHTTPServerTransport;
     server: McpServer;
     userId: string;
+    createdAt: number;
   }>();
+
+  // Periodic MCP session cleanup — remove sessions older than TTL
+  setInterval(() => {
+    const now = Date.now();
+    for (const [sid, session] of sessions) {
+      if (now - session.createdAt > MCP_SESSION_TTL_MS) {
+        slog("info", "session_ttl_expired", { sessionId: sid, userId: session.userId });
+        session.server.close().catch(() => {});
+        sessions.delete(sid);
+      }
+    }
+  }, Math.min(MCP_SESSION_TTL_MS, 60_000)).unref();
 
   const toHeaders = (headers: http.IncomingHttpHeaders) => {
     const result = new Headers();
@@ -2301,9 +2310,9 @@ if (TRANSPORT_MODE === "http") {
   // localStorage and JavaScript memory after the initial exchange.
   // ------------------------------------------------------------------
   const APP_SESSION_COOKIE = "qb-app-sess";
-  const APP_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+  const APP_SESSION_TTL_MS = parseInt(process.env.QUILLBY_APP_SESSION_TTL_MS ?? (7 * 24 * 60 * 60 * 1000).toString(), 10);
 
-  const appSessions = new Map<string, { userId: string; expiresAt: number }>();
+  const appSessions = new Map<string, { userId: string; expiresAt: number; createdAt: number }>();
 
   function parseCookies(req: http.IncomingMessage): Map<string, string> {
     const map = new Map<string, string>();
@@ -2313,7 +2322,7 @@ if (TRANSPORT_MODE === "http") {
       try {
         map.set(part.slice(0, idx).trim(), decodeURIComponent(part.slice(idx + 1).trim()));
       } catch {
-        process.stderr.write("[quillby] Non-fatal: malformed cookie value in parseCookies\n");
+        logWarn("malformed cookie value in parseCookies");
       }
     }
     return map;
@@ -2333,6 +2342,8 @@ if (TRANSPORT_MODE === "http") {
     if (sessionToken) {
       const appSession = appSessions.get(sessionToken);
       if (appSession && appSession.expiresAt > Date.now()) {
+        // Touch — extend TTL on each access
+        appSession.expiresAt = Date.now() + APP_SESSION_TTL_MS;
         return { userId: appSession.userId, mode: "session" };
       }
       // Expired or unknown — clean up lazily
@@ -2348,7 +2359,7 @@ if (TRANSPORT_MODE === "http") {
         return { userId: session.user.id, mode: "session" };
       }
     } catch {
-      process.stderr.write("[quillby] Non-fatal: Better Auth session check failed, falling back to API key\n");
+      logWarn("Better Auth session check failed, falling back to API key");
     }
 
     // 3. Bearer API key (MCP clients and legacy)
@@ -2601,7 +2612,7 @@ if (TRANSPORT_MODE === "http") {
           const userId = verification.key?.referenceId ?? "unknown";
           // Two UUIDs concatenated for extra entropy — 256 bits total.
           const token = `${randomUUID()}-${randomUUID()}`;
-          appSessions.set(token, { userId, expiresAt: Date.now() + APP_SESSION_TTL_MS });
+          appSessions.set(token, { userId, expiresAt: Date.now() + APP_SESSION_TTL_MS, createdAt: Date.now() });
           res.setHeader("Set-Cookie", buildSessionCookie(token, APP_SESSION_TTL_MS / 1000));
           res.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify({ ok: true }));
           finish(200);
@@ -3119,7 +3130,7 @@ if (TRANSPORT_MODE === "http") {
           if (candidate.startsWith(SPA_DIR)) {
             let servePath = candidate;
             let isStaticFile = false;
-            try { isStaticFile = fs.statSync(servePath).isFile(); } catch { process.stderr.write("[quillby] SPA file not found, serving index.html fallback\n"); }
+            try { isStaticFile = fs.statSync(servePath).isFile(); } catch { logWarn("SPA file not found, serving index.html fallback"); }
             if (!isStaticFile) servePath = path.join(SPA_DIR, "index.html");
             const ext = path.extname(servePath).toLowerCase();
             const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
@@ -3192,7 +3203,7 @@ if (TRANSPORT_MODE === "http") {
         }
         const body = Buffer.concat(chunks).toString("utf-8");
         let parsedBody: unknown;
-        try { parsedBody = JSON.parse(body); } catch { process.stderr.write("[quillby] Non-fatal: MCP request body is not valid JSON\n"); parsedBody = undefined; }
+        try { parsedBody = JSON.parse(body); } catch { logWarn("MCP request body is not valid JSON"); parsedBody = undefined; }
 
         const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
@@ -3217,14 +3228,14 @@ if (TRANSPORT_MODE === "http") {
           sessionIdGenerator: () => randomUUID(),
         });
         const sid = transport.sessionId ?? randomUUID();
-        sessions.set(sid, { transport, server: sessionServer, userId });
+        sessions.set(sid, { transport, server: sessionServer, userId, createdAt: Date.now() });
         slog("info", "session_open", { sessionId: sid, userId, sessions: sessions.size });
 
         transport.onclose = () => {
           if (transport.sessionId) {
             const session = sessions.get(transport.sessionId);
             sessions.delete(transport.sessionId);
-            session?.server.close().catch(() => process.stderr.write("[quillby] Non-fatal: server.close failed during session cleanup\n"));
+            session?.server.close().catch(() => logWarn("server.close failed during session cleanup"));
             slog("info", "session_close", { sessionId: transport.sessionId, sessions: sessions.size });
           }
         };
@@ -3279,16 +3290,16 @@ if (TRANSPORT_MODE === "http") {
       verifyApiKey(input: { body: { key: string } }): Promise<{ valid: boolean; key?: { referenceId?: string } }>;
     }).verifyApiKey({ body: { key: rawApiKey } });
     if (!verification.valid) {
-      process.stderr.write("[quillby] QUILLBY_API_KEY is invalid — aborting.\n");
+      logFatal("QUILLBY_API_KEY is invalid — aborting");
       process.exit(1);
     }
     const userId = verification.key?.referenceId;
     if (!userId) {
-      process.stderr.write("[quillby] QUILLBY_API_KEY resolved no user — aborting.\n");
+      logFatal("QUILLBY_API_KEY resolved no user — aborting");
       process.exit(1);
     }
     stdioStorage = getHostedUserStorage(userId) as unknown as WorkspaceStorage & JobStorage & PlanStorage & SessionStore;
-    process.stderr.write(`[quillby] Authenticated as user ${userId} via API key.\n`);
+    logInfo("Authenticated via API key", { userId });
   }
   const server = createMcpServer();
   registerMcpHandlers(server, stdioStorage);
@@ -3302,14 +3313,14 @@ if (TRANSPORT_MODE === "http") {
     const assetsDir = path.join(process.env.QUILLBY_HOME ?? process.env.HOME ?? "~", ".quillby", "assets");
     providerRouter.setTier1(new McpSamplingAdapter(server.server, assetsDir));
   } catch (e) {
-    process.stderr.write(`[quillby] Non-fatal: McpSamplingAdapter init failed (generation falls through to Tier 2): ${e}\n`);
+    logWarn("McpSamplingAdapter init failed (generation falls through to Tier 2)", { error: String(e) });
   }
 }
 
 // Recover orphaned jobs on startup.
 {
   const recovered = await recoverOrphanedJobs(storage as import("@quillby/workspace").JobStorage);
-  if (recovered > 0) process.stderr.write(`[quillby] Recovered ${recovered} orphaned job(s)\n`);
+  if (recovered > 0) logInfo("Recovered orphaned jobs", { count: recovered });
 }
 
 // Scheduled autonomous harvest — fires daily at QUILLBY_SCHEDULE (HH:MM local time).

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -123,10 +123,16 @@ const MEMORY_TYPES = {
 type MemoryTypeInput = keyof typeof MEMORY_TYPES;
 
 const activeJobCounts: Record<string, number> = {};
+function safeParseInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === null) return fallback;
+  const val = parseInt(raw, 10);
+  return Number.isNaN(val) || val < 1 ? fallback : val;
+}
+
 const JOB_CONCURRENCY_LIMITS = {
-  image: parseInt(process.env.QUILLBY_MAX_CONCURRENT_IMAGE ?? "5", 10),
-  audio: parseInt(process.env.QUILLBY_MAX_CONCURRENT_AUDIO ?? "3", 10),
-  video: parseInt(process.env.QUILLBY_MAX_CONCURRENT_VIDEO ?? "2", 10),
+  image: safeParseInt(process.env.QUILLBY_MAX_CONCURRENT_IMAGE, 5),
+  audio: safeParseInt(process.env.QUILLBY_MAX_CONCURRENT_AUDIO, 3),
+  video: safeParseInt(process.env.QUILLBY_MAX_CONCURRENT_VIDEO, 2),
 };
 
 /** Singleton provider router — tier1 is wired after connect in stdio mode; tier2 from cloud env vars. */
@@ -1700,7 +1706,7 @@ ${guide}
           },
           {
             name: "pro",
-            price: process.env.QUILLBY_STRIPE_PRO_PRICE ? "$29/mo" : "$29/mo",
+            price: "$29/mo",
             description: "Unlimited workspaces, drafts, and AI generation credits",
             limits: getPlanLimits("pro"),
           },
@@ -2254,7 +2260,7 @@ if (TRANSPORT_MODE === "http") {
     ".txt":  "text/plain; charset=utf-8",
   };
 
-  const MCP_SESSION_TTL_MS = parseInt(process.env.QUILLBY_MCP_SESSION_TTL_MS ?? (24 * 60 * 60 * 1000).toString(), 10);
+  const MCP_SESSION_TTL_MS = safeParseInt(process.env.QUILLBY_MCP_SESSION_TTL_MS, 24 * 60 * 60 * 1000);
 
   // Map of sessionId → transport, so we can route GET/DELETE back to the right session.
   const sessions = new Map<string, {
@@ -2270,7 +2276,7 @@ if (TRANSPORT_MODE === "http") {
     for (const [sid, session] of sessions) {
       if (now - session.createdAt > MCP_SESSION_TTL_MS) {
         slog("info", "session_ttl_expired", { sessionId: sid, userId: session.userId });
-        session.server.close().catch(() => {});
+        session.server.close().catch((err) => slog("warn", "session_close_error", { error: String(err) }));
         sessions.delete(sid);
       }
     }
@@ -2310,9 +2316,9 @@ if (TRANSPORT_MODE === "http") {
   // localStorage and JavaScript memory after the initial exchange.
   // ------------------------------------------------------------------
   const APP_SESSION_COOKIE = "qb-app-sess";
-  const APP_SESSION_TTL_MS = parseInt(process.env.QUILLBY_APP_SESSION_TTL_MS ?? (7 * 24 * 60 * 60 * 1000).toString(), 10);
+  const APP_SESSION_TTL_MS = safeParseInt(process.env.QUILLBY_APP_SESSION_TTL_MS, 7 * 24 * 60 * 60 * 1000);
 
-  const appSessions = new Map<string, { userId: string; expiresAt: number; createdAt: number }>();
+  const appSessions = new Map<string, { userId: string; expiresAt: number }>();
 
   function parseCookies(req: http.IncomingMessage): Map<string, string> {
     const map = new Map<string, string>();
@@ -2612,7 +2618,7 @@ if (TRANSPORT_MODE === "http") {
           const userId = verification.key?.referenceId ?? "unknown";
           // Two UUIDs concatenated for extra entropy — 256 bits total.
           const token = `${randomUUID()}-${randomUUID()}`;
-          appSessions.set(token, { userId, expiresAt: Date.now() + APP_SESSION_TTL_MS, createdAt: Date.now() });
+          appSessions.set(token, { userId, expiresAt: Date.now() + APP_SESSION_TTL_MS });
           res.setHeader("Set-Cookie", buildSessionCookie(token, APP_SESSION_TTL_MS / 1000));
           res.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify({ ok: true }));
           finish(200);

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -66,6 +66,13 @@ import {
   BillingActionArgsSchema,
 } from "./schemas.js";
 import {
+  checkRateLimit,
+  validateMethod,
+  validateContentType,
+  applySecurityHeaders,
+  sendJsonError,
+} from "./middleware.js";
+import {
   handlePlanCreate,
   handlePlanList,
   handlePlanToday,
@@ -2470,6 +2477,39 @@ if (TRANSPORT_MODE === "http") {
     }
 
     try {
+      // Security headers (applied to all responses)
+      applySecurityHeaders(res, BASE_URL);
+
+      // Method validation — reject unsupported HTTP methods early
+      const methodError = validateMethod(req);
+      if (methodError) {
+        sendJsonError(res, 405, methodError);
+        finish(405);
+        return;
+      }
+
+      // Content-Type validation for POST/PUT with body
+      const contentTypeError = validateContentType(req);
+      if (contentTypeError) {
+        sendJsonError(res, 415, contentTypeError);
+        finish(415);
+        return;
+      }
+
+      // Per-IP rate limiting for non-MCP routes (MCP has its own API-key rate limiting via better-auth)
+      if (url.pathname !== "/mcp") {
+        const clientIp = req.socket.remoteAddress ?? "unknown";
+        const rateLimit = checkRateLimit(clientIp);
+        if (!rateLimit.allowed) {
+          const retryAfter = Math.max(1, Math.ceil(rateLimit.resetMs / 1000));
+          res.setHeader("Retry-After", retryAfter.toString());
+          sendJsonError(res, 429, "Too many requests");
+          finish(429);
+          return;
+        }
+        res.setHeader("X-RateLimit-Remaining", rateLimit.remaining.toString());
+      }
+
       // ------------------------------------------------------------------
       // Health check — unauthenticated, fast
       // ------------------------------------------------------------------

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -3241,7 +3241,7 @@ if (TRANSPORT_MODE === "http") {
           if (transport.sessionId) {
             const session = sessions.get(transport.sessionId);
             sessions.delete(transport.sessionId);
-            session?.server.close().catch(() => logWarn("server.close failed during session cleanup"));
+            session?.server.close().catch((err) => slog("warn", "session_close_error", { error: String(err) }));
             slog("info", "session_close", { sessionId: transport.sessionId, sessions: sessions.size });
           }
         };

--- a/apps/mcp-server/src/mcp/tools/feeds.ts
+++ b/apps/mcp-server/src/mcp/tools/feeds.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { getGoogleNewsFeeds, getMediumTagFeeds, getFeedlyFeeds } from "../../agents/seeds.js";
 import { enrichArticle } from "../../extractors/content.js";
+import { logWarn } from "../../logger.js";
 import type { ToolContext, ToolStorage } from "./index.js";
 
 function extractContextTopics(ctx: Record<string, unknown> | null): string[] {
@@ -132,7 +133,7 @@ Return ONLY a JSON array of strings. 10 items max. No explanation.`;
                 );
               }
             } catch (e) {
-              process.stderr.write(`[quillby] Non-fatal: Sampling response parse failed in discover_feeds: ${e}\n`);
+              logWarn("Sampling response parse failed in discover_feeds", { error: String(e) });
             }
           }
         }

--- a/apps/mcp-server/src/mcp/tools/profile.ts
+++ b/apps/mcp-server/src/mcp/tools/profile.ts
@@ -2,6 +2,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { validateUrl, ElevenLabsAdapter } from "@quillby/providers";
 import { UserContextSchema } from "../../types.js";
 import { resolveElevenLabsApiKey } from "../../provider-config.js";
+import { logWarn } from "../../logger.js";
 import { SetCloneIdentityArgsSchema, CloneVoiceArgsSchema } from "../schemas.js";
 import type { ToolContext } from "./index.js";
 
@@ -303,7 +304,7 @@ export function handleProfileTool(
 
         if (workspace.elevenlabsClonedVoiceId && overwrite) {
           await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId)
-            .catch(() => process.stderr.write("[quillby] Non-fatal: could not delete old ElevenLabs voice clone\n"));
+            .catch(() => logWarn("could not delete old ElevenLabs voice clone"));
         }
 
         const cloneName = voiceName?.trim() || workspace.name || "Quillby Voice Clone";
@@ -343,7 +344,7 @@ export function handleProfileTool(
         const elevenLabsApiKey = resolveElevenLabsApiKey(ctx.deploymentMode);
         if (elevenLabsApiKey) {
           await ElevenLabsAdapter.deleteVoiceClone(elevenLabsApiKey, workspace.elevenlabsClonedVoiceId)
-            .catch(() => process.stderr.write("[quillby] Non-fatal: ElevenLabs deleteVoiceClone failed in delete handler\n"));
+            .catch(() => logWarn("ElevenLabs deleteVoiceClone failed in delete handler"));
         }
 
         await activeStorage.updateWorkspaceMetadata({ elevenlabsClonedVoiceId: "" });

--- a/apps/mcp-server/src/provider-config.ts
+++ b/apps/mcp-server/src/provider-config.ts
@@ -4,6 +4,7 @@ import { createCipheriv, createDecipheriv, createHash, pbkdf2Sync, randomBytes }
 import { execFileSync } from "node:child_process";
 import { CONFIG, ensureDataDir, getDeploymentMode, type DeploymentMode } from "@quillby/config";
 import type { GenerationModality } from "@quillby/core";
+import { logWarn } from "./logger.js";
 import type { ProviderAdapter } from "@quillby/providers";
 import {
   OpenAiGptImageAdapter,
@@ -67,7 +68,7 @@ function loadConfigFile(): ProviderConfigFile {
   try {
     return JSON.parse(fs.readFileSync(file, "utf-8")) as ProviderConfigFile;
   } catch (e) {
-    process.stderr.write(`[quillby] Corrupt provider config file, starting fresh: ${e}\n`);
+    logWarn("Corrupt provider config file, starting fresh", { error: String(e) });
     return {};
   }
 }
@@ -163,7 +164,7 @@ function getKeychainSecret(modality: GenerationModality): string | null {
       "-w",
     ], { encoding: "utf8" }).trim();
   } catch {
-    process.stderr.write(`[quillby] Keychain secret not found for modality "${modality}"\n`);
+    logWarn("Keychain secret not found", { modality });
     return null;
   }
 }
@@ -178,7 +179,7 @@ function deleteKeychainSecret(modality: GenerationModality): void {
       keychainService(modality),
     ]);
   } catch {
-    process.stderr.write(`[quillby] Keychain secret not found for modality "${modality}" (expected on first delete)\n`);
+    logWarn("Keychain secret not found (expected on first delete)", { modality });
   }
 }
 

--- a/apps/mcp-server/tests/unit/middleware.test.ts
+++ b/apps/mcp-server/tests/unit/middleware.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import type http from "node:http";
+import type { Socket } from "node:net";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.QUILLBY_IP_RATE_LIMIT = "60";
+  process.env.QUILLBY_IP_RATE_LIMIT_WINDOW_MS = "60000";
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+type MockRes = http.ServerResponse & {
+  _body: string;
+  _status: number;
+  _headers: Record<string, string>;
+};
+
+function mockReq(overrides: Partial<http.IncomingMessage> = {}): http.IncomingMessage {
+  return {
+    method: "GET",
+    headers: {},
+    socket: {} as Socket,
+    ...overrides,
+  } as unknown as http.IncomingMessage;
+}
+
+function mockRes(): MockRes {
+  const headers: Record<string, string> = {};
+  let status = 200;
+  let body = "";
+  let sent = false;
+  const self: MockRes = {
+    _body: "",
+    _status: 200,
+    _headers: headers,
+    setHeader(k: string, v: string | number | readonly string[]) { headers[k] = String(v); return self; },
+    getHeader(k: string) { return headers[k]; },
+    get headersSent() { return sent; },
+    writeHead(s: number, h?: Record<string, string | number | readonly string[]>) {
+      status = s;
+      if (h) {
+        for (const [k, v] of Object.entries(h)) {
+          headers[k] = String(v);
+        }
+      }
+      return self;
+    },
+    end(b?: string) { body = b ?? ""; sent = true; return self; },
+  } as unknown as MockRes;
+  Object.defineProperty(self, "_body", { get: () => body });
+  Object.defineProperty(self, "_status", { get: () => status });
+  Object.defineProperty(self, "_headers", { get: () => headers });
+  return self;
+}
+
+// ---------------------------------------------------------------------------
+// checkRateLimit
+// ---------------------------------------------------------------------------
+describe("checkRateLimit", () => {
+  it("allows first request and reports remaining as MAX-1", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const result = mod.checkRateLimit(`first-${Date.now()}`);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(59);
+    expect(result.resetMs).toBe(0);
+  });
+
+  it("decrements remaining on consecutive requests", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const ip = `decrement-${Date.now()}`;
+    expect(mod.checkRateLimit(ip).remaining).toBe(59);
+    expect(mod.checkRateLimit(ip).remaining).toBe(58);
+    expect(mod.checkRateLimit(ip).remaining).toBe(57);
+  });
+
+  it("different IPs have independent counters", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const ipA = `indep-A-${Date.now()}`;
+    const ipB = `indep-B-${Date.now()}`;
+    expect(mod.checkRateLimit(ipA).allowed).toBe(true);
+    expect(mod.checkRateLimit(ipB).allowed).toBe(true);
+  });
+
+  it("denies requests that exceed MAX and reports resetMs", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const ip = `exceed-${Date.now()}`;
+    for (let i = 0; i < 60; i++) {
+      mod.checkRateLimit(ip);
+    }
+    const last = mod.checkRateLimit(ip);
+    expect(last.allowed).toBe(false);
+    expect(last.remaining).toBe(0);
+    expect(last.resetMs).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateMethod
+// ---------------------------------------------------------------------------
+describe("validateMethod", () => {
+  it("allows GET", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "GET" }))).toBeNull();
+  });
+
+  it("allows POST", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "POST" }))).toBeNull();
+  });
+
+  it("allows PUT", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "PUT" }))).toBeNull();
+  });
+
+  it("allows DELETE", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "DELETE" }))).toBeNull();
+  });
+
+  it("allows OPTIONS", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "OPTIONS" }))).toBeNull();
+  });
+
+  it("rejects PATCH", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "PATCH" }))).toBe("Method PATCH not allowed");
+  });
+
+  it("rejects unknown method", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: "CONNECT" }))).toBe("Method CONNECT not allowed");
+  });
+
+  it("rejects missing method", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    expect(mod.validateMethod(mockReq({ method: undefined }))).toBe("Method undefined not allowed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateContentType
+// ---------------------------------------------------------------------------
+describe("validateContentType", () => {
+  it("passes POST with application/json", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "POST", headers: { "content-type": "application/json" } });
+    expect(mod.validateContentType(req)).toBeNull();
+  });
+
+  it("passes POST with application/json; charset=utf-8", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "POST", headers: { "content-type": "application/json; charset=utf-8" } });
+    expect(mod.validateContentType(req)).toBeNull();
+  });
+
+  it("passes POST with multipart/form-data", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "POST", headers: { "content-type": "multipart/form-data; boundary=abc123" } });
+    expect(mod.validateContentType(req)).toBeNull();
+  });
+
+  it("rejects POST with text/plain", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "POST", headers: { "content-type": "text/plain" } });
+    expect(mod.validateContentType(req)).toBe(
+      "Unsupported Content-Type: expected application/json or multipart/form-data",
+    );
+  });
+
+  it("rejects POST with application/xml", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "POST", headers: { "content-type": "application/xml" } });
+    expect(mod.validateContentType(req)).toBe(
+      "Unsupported Content-Type: expected application/json or multipart/form-data",
+    );
+  });
+
+  it("rejects POST with no Content-Type header", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "POST", headers: {} });
+    expect(mod.validateContentType(req)).toBe(
+      "Unsupported Content-Type: expected application/json or multipart/form-data",
+    );
+  });
+
+  it("passes GET regardless of Content-Type", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "GET", headers: { "content-type": "text/plain" } });
+    expect(mod.validateContentType(req)).toBeNull();
+  });
+
+  it("passes DELETE regardless of Content-Type", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "DELETE", headers: { "content-type": "text/plain" } });
+    expect(mod.validateContentType(req)).toBeNull();
+  });
+
+  it("rejects PUT with text/plain", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "PUT", headers: { "content-type": "text/plain" } });
+    expect(mod.validateContentType(req)).toBe(
+      "Unsupported Content-Type: expected application/json or multipart/form-data",
+    );
+  });
+
+  it("passes PUT with application/json", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const req = mockReq({ method: "PUT", headers: { "content-type": "application/json" } });
+    expect(mod.validateContentType(req)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySecurityHeaders
+// ---------------------------------------------------------------------------
+describe("applySecurityHeaders", () => {
+  it("sets X-Content-Type-Options to nosniff", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res);
+    expect(res._headers["X-Content-Type-Options"]).toBe("nosniff");
+  });
+
+  it("sets X-Frame-Options to DENY", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res);
+    expect(res._headers["X-Frame-Options"]).toBe("DENY");
+  });
+
+  it("sets Referrer-Policy", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res);
+    expect(res._headers["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("sets X-XSS-Protection to 0", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res);
+    expect(res._headers["X-XSS-Protection"]).toBe("0");
+  });
+
+  it("does not set HSTS when baseUrl is http", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res, "http://localhost:3000");
+    expect(res._headers["Strict-Transport-Security"]).toBeUndefined();
+  });
+
+  it("sets HSTS when baseUrl is https", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res, "https://quillby.example.com");
+    expect(res._headers["Strict-Transport-Security"]).toBe("max-age=31536000; includeSubDomains");
+  });
+
+  it("does not set HSTS when baseUrl is omitted", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.applySecurityHeaders(res);
+    expect(res._headers["Strict-Transport-Security"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendJsonError
+// ---------------------------------------------------------------------------
+describe("sendJsonError", () => {
+  it("writes error as JSON with correct status", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.sendJsonError(res, 429, "Too many requests");
+    expect(JSON.parse(res._body as string)).toEqual({ error: "Too many requests" });
+  });
+
+  it("includes extra fields when provided", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.sendJsonError(res, 400, "Bad request", { field: "name" });
+    expect(JSON.parse(res._body as string)).toEqual({ error: "Bad request", field: "name" });
+  });
+
+  it("sets Content-Type header to application/json", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    mod.sendJsonError(res, 400, "Bad request");
+    expect(res._headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("is a no-op if headers already sent", async () => {
+    const mod = await import("../../src/mcp/middleware.js");
+    const res = mockRes();
+    Object.defineProperty(res, "headersSent", { value: true });
+    const before = res._body;
+    mod.sendJsonError(res, 500, "fail");
+    expect(res._body).toBe(before);
+  });
+});

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -62,4 +62,7 @@ COPY --from=build-app /app/apps/app/dist ./public/app
 VOLUME ["/data"]
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+
 CMD ["node", "dist/mcp/server.js"]

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -63,6 +63,6 @@ VOLUME ["/data"]
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+  CMD wget -q --spider http://localhost:3000/health || exit 1
 
 CMD ["node", "dist/mcp/server.js"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       nanostores:
         specifier: ^1.1.0
         version: 1.2.0
+      nodemailer:
+        specifier: ^8.0.9
+        version: 8.0.9
       rss-parser:
         specifier: ^3.13.0
         version: 3.13.0
@@ -178,6 +181,9 @@ importers:
       '@types/node':
         specifier: ^20.11.24
         version: 20.19.37
+      '@types/nodemailer':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
@@ -1127,6 +1133,7 @@ packages:
 
   '@evilmartians/lefthook@2.1.8':
     resolution: {integrity: sha512-1hzdKBlPhy7SQWQOEMzt15VZ4xKNZGdOECbEhbAQc9B83vtn9Kx6ez5ciq/83RDyMSd1poAeXD0MibEowVenJw==}
+    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2500,6 +2507,9 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
+  '@types/nodemailer@8.0.0':
+    resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -3846,6 +3856,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -4191,6 +4202,10 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  nodemailer@8.0.9:
+    resolution: {integrity: sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -7723,6 +7738,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@8.0.0':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -9667,6 +9686,8 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.36: {}
+
+  nodemailer@8.0.9: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## REQ-000234: Harden operations for self-hosted and cloud modes

Completes 4 tasks under REQ-000234:

### T-000318: Rate limiting + request validation middleware
- Per-IP sliding window rate limiter (default 60 req/min, configurable via `QUILLBY_IP_RATE_LIMIT`)
- HTTP method whitelist (GET/POST/PUT/DELETE/OPTIONS)
- Content-Type enforcement for POST/PUT (application/json or multipart/form-data)
- Security headers: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `X-XSS-Protection`, HSTS (when HTTPS)
- 33 unit tests

### T-000343: Structured logging
- Centralized `logger.ts` module with `slog()` and level helpers (info/warn/error/fatal)
- Replaced all 34 ad-hoc `process.stderr.write` calls across 4 files
- JSON-line format with timestamp, level, message, and structured extra data
- `JSON.stringify` safely wrapped in try/catch

### T-000321: Session TTL + Docker healthcheck
- Configurable app session TTL via `QUILLBY_APP_SESSION_TTL_MS` (defaults to 7 days)
- Configurable MCP session TTL via `QUILLBY_MCP_SESSION_TTL_MS` (defaults to 24h) with periodic cleanup
- App session refresh (TTL extended on each access)
- Session close errors are logged, not silently swallowed
- Docker `HEALTHCHECK` added (BusyBox-compatible `wget -q --spider`)

### T-000319: Email integration
- SMTP email sender via nodemailer (cached transporter singleton)
- Better-auth wired for email verification and password reset
- Graceful fallback when SMTP is not configured (logs URL instead)
- Send errors are caught and logged without crashing the auth flow

### Quality
- Fixed `parseInt` NaN vulnerabilities (env var parsing now uses `safeParseInt` with fallbacks)
- All pre-commit hooks pass: gitleaks, 12-package lint, 12-package typecheck
- 436 unit tests pass (39 files)
