### PR TITLE
feat(monorepo): extract auth adapter into @quillby/auth and remove empty stubs

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -28,7 +28,7 @@
   ],
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter @quillby/core --filter @quillby/config --filter @quillby/content --filter @quillby/workspace --filter @quillby/database --filter @quillby/billing --filter @quillby/storage-fs --filter @quillby/storage-db --filter @quillby/providers build",
+    "prebuild": "pnpm --filter @quillby/core --filter @quillby/config --filter @quillby/content --filter @quillby/auth --filter @quillby/workspace --filter @quillby/database --filter @quillby/billing --filter @quillby/storage-fs --filter @quillby/storage-db --filter @quillby/providers build",
     "prepare": "pnpm run build",
     "mcp": "node dist/mcp/server.js",
     "mcp:dev": "tsx src/mcp/server.ts",
@@ -59,6 +59,7 @@
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@mozilla/readability": "^0.6.0",
     "@opentelemetry/api": "^1.9.0",
+    "@quillby/auth": "workspace:*",
     "@quillby/billing": "workspace:*",
     "@quillby/config": "workspace:*",
     "@quillby/content": "workspace:*",

--- a/apps/mcp-server/src/auth.ts
+++ b/apps/mcp-server/src/auth.ts
@@ -1,42 +1,16 @@
-import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { apiKey } from "@better-auth/api-key";
+import { createAuth, parseRateLimit } from "@quillby/auth";
 import { db } from "./db.js";
 import * as schema from "./db/schema.js";
 import { sendVerificationEmail, sendResetPasswordEmail } from "./email.js";
 import { slog } from "./logger.js";
-
-// QUILLBY_RATE_LIMIT sets the default max requests per minute for new API keys.
-// Individual keys can override this at creation time via manage-keys.ts.
-export function parseRateLimit(raw?: string): number {
-  const value = parseInt(raw ?? "60", 10);
-  if (Number.isNaN(value) || value < 1) return 60;
-  return value;
-}
-
-const defaultRateLimitMax = parseRateLimit(process.env.QUILLBY_RATE_LIMIT);
-type BetterAuthOptions = Parameters<typeof betterAuth>[0];
-
-const apiKeyPlugin = apiKey({
-  // Keys are validated on every /mcp request — enableSessionForAPIKeys
-  // is OFF to avoid the per-request double-hit on rate limit counters.
-  enableSessionForAPIKeys: false,
-
-  // Default rate-limit window: 60 requests per 60 seconds.
-  // These defaults apply when a key is created without explicit limits.
-  rateLimit: {
-    enabled: true,
-    maxRequests: defaultRateLimitMax,
-    timeWindow: 60_000,
-  },
-}) as unknown as NonNullable<BetterAuthOptions["plugins"]>[number];
 
 const corsOrigin = process.env.QUILLBY_CORS_ORIGIN;
 const trustedOrigins = corsOrigin && corsOrigin !== "*"
   ? corsOrigin.split(",").map((o) => o.trim()).filter(Boolean)
   : [];
 
-export const auth = betterAuth({
+export const auth = createAuth({
   database: drizzleAdapter(db, {
     provider: "sqlite",
     schema: {
@@ -47,25 +21,12 @@ export const auth = betterAuth({
       apikey: schema.apikey,
     },
   }),
-
   emailAndPassword: {
-    enabled: true,
-    sendEmailVerification: true,
-    async sendVerificationEmail(data: { user: { email: string; name?: string }; url: string }) {
-      await sendVerificationEmail(data.user, data.url);
-    },
-    async sendResetPassword(data: { user: { email: string; name?: string }; url: string }) {
-      await sendResetPasswordEmail(data.user, data.url);
-    },
+    sendVerificationEmail: (data) => sendVerificationEmail(data.user, data.url),
+    sendResetPassword: (data) => sendResetPasswordEmail(data.user, data.url),
   },
-
-  // Allow the app origin (e.g. http://localhost:5173 in dev) to make
-  // credentialed auth requests without Better Auth's CSRF 403 rejection.
-  ...(trustedOrigins.length > 0 ? { trustedOrigins } : {}),
-
-  plugins: [
-    apiKeyPlugin,
-  ],
+  rateLimitMax: parseRateLimit(process.env.QUILLBY_RATE_LIMIT),
+  trustedOrigins,
 });
 
 if (process.env.QUILLBY_SMTP_HOST) {

--- a/apps/mcp-server/src/cli/keys.ts
+++ b/apps/mcp-server/src/cli/keys.ts
@@ -22,40 +22,13 @@
  */
 
 import "dotenv/config";
+import { AuthApi, parseRateLimit, listApiKeysFromDb, deleteApiKeyFromDb } from "@quillby/auth";
 import { auth } from "../auth.js";
+import { db, apikey as apikeyTable } from "../db.js";
+
+const authApi = new AuthApi(auth);
 
 const [, , command, ...args] = process.argv;
-
-// ── Type-unsafe but runtime-correct wrappers for @better-auth/api-key methods.
-// These methods exist at runtime via the plugin but are not reflected in the typed API.
-
-const createApiKey = (userId: string, name: string, rateLimitMax: number) =>
-  (auth.api as unknown as {
-    createApiKey(input: {
-      body: {
-        userId: string;
-        name: string;
-        prefix: string;
-        rateLimitEnabled: boolean;
-        rateLimitTimeWindow: number;
-        rateLimitMax: number;
-      };
-    }): Promise<{ id: string; key: string }>;
-  }).createApiKey({
-    body: { userId, name, prefix: "qb", rateLimitEnabled: true, rateLimitTimeWindow: 60_000, rateLimitMax },
-  });
-
-interface ListedApiKey { id: string; name?: string | null; start?: string | null }
-
-const listApiKeys = (userId: string): Promise<ListedApiKey[]> =>
-  (auth.api as unknown as {
-    listApiKeys(input: { body: { userId: string } }): Promise<ListedApiKey[]>;
-  }).listApiKeys({ body: { userId } });
-
-const deleteApiKey = (keyId: string): Promise<void> =>
-  (auth.api as unknown as {
-    deleteApiKey(input: { body: { keyId: string } }): Promise<void>;
-  }).deleteApiKey({ body: { keyId } });
 
 async function main(): Promise<void> {
   switch (command) {
@@ -65,7 +38,7 @@ async function main(): Promise<void> {
         console.error("Usage: keys create-user <email> <password> <name>");
         process.exit(1);
       }
-      const result = await auth.api.signUpEmail({ body: { email, password, name } });
+      const result = await authApi.signUpEmail(email, password, name);
       console.log("Created user:");
       console.log(JSON.stringify({ id: result.user.id, email: result.user.email, name: result.user.name }, null, 2));
       break;
@@ -79,8 +52,8 @@ async function main(): Promise<void> {
       }
       const rateLimitMax = limitArg
         ? parseInt(limitArg, 10)
-        : parseInt(process.env.QUILLBY_RATE_LIMIT ?? "60", 10);
-      const result = await createApiKey(userId, keyName, rateLimitMax);
+        : parseRateLimit(process.env.QUILLBY_RATE_LIMIT);
+      const result = await authApi.createApiKey(userId, keyName, rateLimitMax);
       console.log("Created API key (shown only once — save it now):");
       console.log(JSON.stringify({ key: result.key, id: result.id, name: keyName, userId, rateLimitMax }, null, 2));
       break;
@@ -92,7 +65,7 @@ async function main(): Promise<void> {
         console.error("Usage: keys list <userId>");
         process.exit(1);
       }
-      const keys = await listApiKeys(userId);
+      const keys = await listApiKeysFromDb(db, apikeyTable, userId);
       if (!keys || (Array.isArray(keys) && keys.length === 0)) {
         console.log("No keys found for user:", userId);
       } else {
@@ -107,7 +80,7 @@ async function main(): Promise<void> {
         console.error("Usage: keys revoke <keyId>");
         process.exit(1);
       }
-      await deleteApiKey(keyId);
+      await deleteApiKeyFromDb(db, apikeyTable, keyId);
       console.log(`Revoked key: ${keyId}`);
       break;
     }

--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { toNodeHandler } from "better-auth/node";
 import { slog, logInfo, logWarn, logError, logFatal } from "../logger.js";
 import { auth } from "../auth.js";
+import { AuthApi, serializeApiKey, listApiKeysFromDb, deleteApiKeyFromDb, type ListedApiKey } from "@quillby/auth";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -16,7 +17,6 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { eq } from "drizzle-orm";
 import { UserContextSchema, CardInputSchema } from "../types.js";
 import {
   contextToPromptText,
@@ -145,6 +145,8 @@ for (const warning of verifyProviderEnv()) {
 }
 
 const SERVER_INFO = { name: "quillby-mcp", version: "2.0.0" } as const;
+
+const authApi = new AuthApi(auth);
 
 function validateEnv(): void {
   const mode = getDeploymentMode();
@@ -2373,7 +2375,7 @@ if (TRANSPORT_MODE === "http") {
     const bearerMatch = authHeader.match(/^Bearer (.+)$/i);
     if (!bearerMatch) return null;
 
-    const verification = await verifyApiKey(bearerMatch[1]);
+    const verification = await authApi.verifyApiKey(bearerMatch[1]);
     if (!verification.valid) return null;
 
     return {
@@ -2403,71 +2405,6 @@ if (TRANSPORT_MODE === "http") {
         return "skip";
     }
   };
-
-  interface VerifiedApiKey {
-    valid: boolean;
-    key?: {
-      referenceId?: string | null;
-    } | null;
-  }
-
-  interface ListedApiKey {
-    id: string;
-    name?: string | null;
-    prefix?: string | null;
-    start?: string | null;
-    enabled?: boolean | null;
-    createdAt?: Date | string | number | null;
-    expiresAt?: Date | string | number | null;
-    rateLimitMax?: number | null;
-    rateLimitTimeWindow?: number | null;
-  }
-
-  const verifyApiKey = (key: string): Promise<VerifiedApiKey> =>
-    (auth.api as unknown as {
-      verifyApiKey(input: { body: { key: string } }): Promise<VerifiedApiKey>;
-    }).verifyApiKey({ body: { key } });
-
-  const listApiKeys = (userId: string): Promise<ListedApiKey[]> =>
-    db.select().from(apikeyTable).where(eq(apikeyTable.referenceId, userId)) as Promise<ListedApiKey[]>;
-
-  const createApiKey = (userId: string, name: string, rateLimitMax: number) =>
-    (auth.api as unknown as {
-      createApiKey(input: {
-        body: {
-          userId: string;
-          name: string;
-          prefix: string;
-          rateLimitEnabled: boolean;
-          rateLimitTimeWindow: number;
-          rateLimitMax: number;
-        };
-      }): Promise<{ id: string; key: string }>;
-    }).createApiKey({
-      body: {
-        userId,
-        name,
-        prefix: "qb",
-        rateLimitEnabled: true,
-        rateLimitTimeWindow: 60_000,
-        rateLimitMax,
-      },
-    });
-
-  const deleteApiKey = (keyId: string): Promise<void> =>
-    db.delete(apikeyTable).where(eq(apikeyTable.id, keyId)).then(() => undefined);
-
-  const serializeApiKey = (key: ListedApiKey) => ({
-    id: key.id,
-    name: key.name ?? "Unnamed key",
-    prefix: key.prefix ?? null,
-    start: key.start ?? null,
-    enabled: key.enabled ?? true,
-    createdAt: key.createdAt ? new Date(key.createdAt).toISOString() : undefined,
-    expiresAt: key.expiresAt ? new Date(key.expiresAt).toISOString() : null,
-    rateLimitMax: key.rateLimitMax ?? null,
-    rateLimitTimeWindow: key.rateLimitTimeWindow ?? null,
-  });
 
   const httpServer = http.createServer(async (req, res) => {
     const start = Date.now();
@@ -2609,7 +2546,7 @@ if (TRANSPORT_MODE === "http") {
             finish(400);
             return;
           }
-          const verification = await verifyApiKey(body.apiKey);
+          const verification = await authApi.verifyApiKey(body.apiKey);
           if (!verification.valid) {
             res.writeHead(401).end(JSON.stringify({ error: "Invalid API key" }));
             finish(401);
@@ -2894,7 +2831,7 @@ if (TRANSPORT_MODE === "http") {
         }
 
         if (url.pathname === "/api/app/api-keys" && req.method === "GET") {
-          const keys = await listApiKeys(authState.userId);
+          const keys = await listApiKeysFromDb(db, apikeyTable, authState.userId);
           res.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify({
             keys: keys.map(serializeApiKey),
           }));
@@ -2915,9 +2852,9 @@ if (TRANSPORT_MODE === "http") {
             ? Math.max(1, Math.floor(body.rateLimitMax))
             : parseInt(process.env.QUILLBY_RATE_LIMIT ?? "60", 10);
 
-          const result = await createApiKey(authState.userId, keyName, rateLimitMax);
-          const keys = await listApiKeys(authState.userId);
-          const meta = keys.find((entry) => entry.id === result.id);
+          const result = await authApi.createApiKey(authState.userId, keyName, rateLimitMax);
+          const keys = await listApiKeysFromDb(db, apikeyTable, authState.userId);
+          const meta = keys.find((entry: ListedApiKey) => entry.id === result.id);
 
           res.writeHead(200, { "Content-Type": "application/json" }).end(JSON.stringify({
             key: result.key,
@@ -2934,7 +2871,7 @@ if (TRANSPORT_MODE === "http") {
             finish(400);
             return;
           }
-          await deleteApiKey(body.keyId);
+          await deleteApiKeyFromDb(db, apikeyTable, body.keyId);
           res.writeHead(204).end();
           finish(204);
           return;
@@ -3161,7 +3098,7 @@ if (TRANSPORT_MODE === "http") {
         return;
       }
 
-      const verification = await verifyApiKey(bearerMatch[1]);
+      const verification = await authApi.verifyApiKey(bearerMatch[1]);
       if (!verification.valid) {
         res.writeHead(401, { "WWW-Authenticate": 'Bearer realm="quillby-mcp"' }).end("Unauthorized");
         finish(401);
@@ -3292,9 +3229,7 @@ if (TRANSPORT_MODE === "http") {
   let stdioStorage = storage as unknown as WorkspaceStorage & JobStorage & PlanStorage & SessionStore;
   const rawApiKey = process.env.QUILLBY_API_KEY?.trim();
   if (rawApiKey && isCloudMode()) {
-    const verification = await (auth.api as unknown as {
-      verifyApiKey(input: { body: { key: string } }): Promise<{ valid: boolean; key?: { referenceId?: string } }>;
-    }).verifyApiKey({ body: { key: rawApiKey } });
+    const verification = await authApi.verifyApiKey(rawApiKey);
     if (!verification.valid) {
       logFatal("QUILLBY_API_KEY is invalid — aborting");
       process.exit(1);

--- a/apps/mcp-server/tests/unit/auth.test.ts
+++ b/apps/mcp-server/tests/unit/auth.test.ts
@@ -1,15 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-vi.mock("better-auth", () => ({ betterAuth: vi.fn(() => ({})) }));
-vi.mock("better-auth/adapters/drizzle", () => ({ drizzleAdapter: vi.fn() }));
-vi.mock("@better-auth/api-key", () => ({ apiKey: vi.fn(() => ({})) }));
-vi.mock("../../src/db.js", () => ({ db: {} }));
-vi.mock("../../src/db/schema.js", async (importOriginal) => {
-  const actual: Record<string, unknown> = await importOriginal();
-  return actual;
-});
-
-import { parseRateLimit } from "../../src/auth.js";
+import { parseRateLimit } from "@quillby/auth";
 
 describe("parseRateLimit", () => {
   it("defaults to 60 when undefined", () => {

--- a/apps/mcp-server/tests/unit/rate-limiting.test.ts
+++ b/apps/mcp-server/tests/unit/rate-limiting.test.ts
@@ -1,15 +1,6 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
 
-vi.mock("better-auth", () => ({ betterAuth: vi.fn() }));
-vi.mock("better-auth/adapters/drizzle", () => ({ drizzleAdapter: vi.fn() }));
-vi.mock("@better-auth/api-key", () => ({ apiKey: vi.fn(() => ({})) }));
-vi.mock("../../src/db.js", () => ({ db: {} }));
-vi.mock("../../src/db/schema.js", async (importOriginal) => {
-  const actual: Record<string, unknown> = await importOriginal();
-  return actual;
-});
-
-import { parseRateLimit } from "../../src/auth.js";
+import { parseRateLimit } from "@quillby/auth";
 
 function getConcurrencyLimits(overrides?: {
   image?: string;

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@quillby/auth",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@better-auth/api-key": "^1.5.6",
+    "better-auth": "^1.5.6",
+    "drizzle-orm": "^0.45.2"
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,186 @@
+import { betterAuth } from "better-auth";
+import { apiKey } from "@better-auth/api-key";
+import { sql } from "drizzle-orm";
+
+type BetterAuthOptions = Parameters<typeof betterAuth>[0];
+
+export interface VerifiedApiKey {
+  valid: boolean;
+  key?: {
+    id?: string;
+    referenceId?: string | null;
+    userId?: string;
+  } | null;
+}
+
+export interface ListedApiKey {
+  id: string;
+  name?: string | null;
+  prefix?: string | null;
+  start?: string | null;
+  enabled?: boolean | null;
+  createdAt?: Date | string | number | null;
+  expiresAt?: Date | string | number | null;
+  rateLimitMax?: number | null;
+  rateLimitTimeWindow?: number | null;
+}
+
+export interface SerializedApiKey {
+  id: string;
+  name: string;
+  prefix: string | null;
+  start: string | null;
+  enabled: boolean;
+  createdAt: string | null;
+  expiresAt: string | null;
+  rateLimitMax: number | null;
+  rateLimitTimeWindow: number | null;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+}
+
+export function parseRateLimit(raw?: string): number {
+  const value = parseInt(raw ?? "60", 10);
+  if (Number.isNaN(value) || value < 1) return 60;
+  return value;
+}
+
+export function serializeApiKey(key: ListedApiKey): SerializedApiKey {
+  return {
+    id: key.id,
+    name: key.name ?? "Unnamed key",
+    prefix: key.prefix ?? null,
+    start: key.start ?? null,
+    enabled: key.enabled ?? true,
+    createdAt: key.createdAt ? new Date(key.createdAt).toISOString() : null,
+    expiresAt: key.expiresAt ? new Date(key.expiresAt).toISOString() : null,
+    rateLimitMax: key.rateLimitMax ?? null,
+    rateLimitTimeWindow: key.rateLimitTimeWindow ?? null,
+  };
+}
+
+export interface AuthEmailService {
+  sendVerificationEmail(data: { user: { email: string; name?: string }; url: string }): Promise<void>;
+  sendResetPassword(data: { user: { email: string; name?: string }; url: string }): Promise<void>;
+}
+
+export interface AuthConfig {
+  database: NonNullable<BetterAuthOptions["database"]>;
+  emailAndPassword?: AuthEmailService;
+  rateLimitMax?: number;
+  trustedOrigins?: string[];
+}
+
+export function createAuth(config: AuthConfig): ReturnType<typeof betterAuth> {
+  const { database, emailAndPassword, rateLimitMax = 60, trustedOrigins = [] } = config;
+
+  const apiKeyPlugin = apiKey({
+    enableSessionForAPIKeys: false,
+    rateLimit: {
+      enabled: true,
+      maxRequests: rateLimitMax,
+      timeWindow: 60_000,
+    },
+  }) as unknown as NonNullable<BetterAuthOptions["plugins"]>[number];
+
+  const opts: Record<string, unknown> = {
+    database,
+    plugins: [apiKeyPlugin],
+  };
+
+  if (emailAndPassword) {
+    opts.emailAndPassword = {
+      enabled: true,
+      sendEmailVerification: true,
+      sendVerificationEmail: emailAndPassword.sendVerificationEmail,
+      sendResetPassword: emailAndPassword.sendResetPassword,
+    };
+  }
+
+  if (trustedOrigins.length > 0) {
+    opts.trustedOrigins = trustedOrigins;
+  }
+
+  return betterAuth(opts as unknown as BetterAuthOptions);
+}
+
+export class AuthApi {
+  constructor(private auth: ReturnType<typeof betterAuth>) {}
+
+  async verifyApiKey(key: string): Promise<VerifiedApiKey> {
+    return (this.auth.api as unknown as {
+      verifyApiKey(input: { body: { key: string } }): Promise<VerifiedApiKey>;
+    }).verifyApiKey({ body: { key } });
+  }
+
+  async createApiKey(
+    userId: string,
+    name: string,
+    rateLimitMax: number,
+  ): Promise<{ id: string; key: string }> {
+    return (this.auth.api as unknown as {
+      createApiKey(input: {
+        body: {
+          userId: string;
+          name: string;
+          prefix: string;
+          rateLimitEnabled: boolean;
+          rateLimitTimeWindow: number;
+          rateLimitMax: number;
+        };
+      }): Promise<{ id: string; key: string }>;
+    }).createApiKey({
+      body: {
+        userId,
+        name,
+        prefix: "qb",
+        rateLimitEnabled: true,
+        rateLimitTimeWindow: 60_000,
+        rateLimitMax,
+      },
+    });
+  }
+
+  async signUpEmail(
+    email: string,
+    password: string,
+    name: string,
+  ): Promise<{ user: AuthUser }> {
+    return (this.auth.api as unknown as {
+      signUpEmail(input: { body: { email: string; password: string; name: string } }): Promise<{ user: AuthUser }>;
+    }).signUpEmail({ body: { email, password, name } });
+  }
+
+  async getSession(headers: Record<string, string>): Promise<{ user?: { id: string } } | null> {
+    const result = await (this.auth.api as unknown as {
+      getSession(input: { headers: Record<string, string> }): Promise<{ user?: { id: string } } | null>;
+    }).getSession({ headers });
+    return result;
+  }
+}
+
+export function listApiKeysFromDb(
+  db: unknown,
+  apikeyTable: unknown,
+  userId: string,
+): Promise<ListedApiKey[]> {
+  const _db = db as { select(): { from(table: unknown): { where(condition: unknown): Promise<ListedApiKey[]> } } };
+  const _table = apikeyTable as { referenceId: unknown; id: unknown };
+  return _db.select().from(apikeyTable).where(
+    sql`${_table.referenceId} = ${userId}`,
+  ) as Promise<ListedApiKey[]>;
+}
+
+export async function deleteApiKeyFromDb(
+  db: unknown,
+  apikeyTable: unknown,
+  keyId: string,
+): Promise<void> {
+  const _db = db as { delete(table: unknown): { where(condition: unknown): Promise<void> } };
+  const _table = apikeyTable as { id: unknown };
+  await (_db.delete(apikeyTable).where(sql`${_table.id} = ${keyId}`) as Promise<void>);
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tooling/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/extractors/README.md
+++ b/packages/extractors/README.md
@@ -1,3 +1,0 @@
-# Extractors
-
-Reserved for content ingestion adapters such as RSS, Reddit, and article parsing.

--- a/packages/mcp-kit/README.md
+++ b/packages/mcp-kit/README.md
@@ -1,3 +1,0 @@
-# MCP Kit
-
-Reserved for MCP protocol wiring, tool registration, and prompt/resource adapters.

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -1,3 +1,0 @@
-# Observability
-
-Reserved for shared logging, health, and metrics helpers.

--- a/packages/ui-contracts/README.md
+++ b/packages/ui-contracts/README.md
@@ -1,3 +1,0 @@
-# UI Contracts
-
-Reserved for shared DTOs between the server and browser apps.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
+      '@quillby/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
       '@quillby/billing':
         specifier: workspace:*
         version: link:../../packages/billing
@@ -230,6 +233,18 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/auth:
+    dependencies:
+      '@better-auth/api-key':
+        specifier: ^1.5.6
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.4(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))))
+      better-auth:
+        specifier: ^1.5.6
+        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15)
 
   packages/billing:
     dependencies:
@@ -1133,7 +1148,6 @@ packages:
 
   '@evilmartians/lefthook@2.1.8':
     resolution: {integrity: sha512-1hzdKBlPhy7SQWQOEMzt15VZ4xKNZGdOECbEhbAQc9B83vtn9Kx6ez5ciq/83RDyMSd1poAeXD0MibEowVenJw==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -3856,7 +3870,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -5485,6 +5498,13 @@ snapshots:
       better-auth: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
       zod: 4.3.6
 
+  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.4(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))))':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.4(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
+      '@better-auth/utils': 0.3.1
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      zod: 4.3.6
+
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.4(zod@3.25.76))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
@@ -5493,6 +5513,19 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.4(zod@3.25.76)
+      jose: 6.2.2
+      kysely: 0.28.15
+      nanostores: 1.2.0
+      zod: 4.3.6
+
+  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.4(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)':
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.4(zod@4.3.6)
       jose: 6.2.2
       kysely: 0.28.15
       nanostores: 1.2.0
@@ -8218,6 +8251,15 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 3.25.76
+
+  better-call@1.3.4(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.3.6
 
   better-path-resolve@1.0.0:
     dependencies:

--- a/tooling/scripts/manage-keys.ts
+++ b/tooling/scripts/manage-keys.ts
@@ -22,7 +22,11 @@
  */
 
 import "dotenv/config";
+import { AuthApi, parseRateLimit, listApiKeysFromDb, deleteApiKeyFromDb } from "@quillby/auth";
 import { auth } from "../src/auth.js";
+import { db, apikey as apikeyTable } from "../src/db.js";
+
+const authApi = new AuthApi(auth);
 
 const [, , command, ...args] = process.argv;
 
@@ -34,7 +38,7 @@ async function main(): Promise<void> {
         console.error("Usage: manage-keys.ts create-user <email> <password> <name>");
         process.exit(1);
       }
-      const result = await auth.api.signUpEmail({ body: { email, password, name } });
+      const result = await authApi.signUpEmail(email, password, name);
       console.log("Created user:");
       console.log(JSON.stringify({ id: result.user.id, email: result.user.email, name: result.user.name }, null, 2));
       break;
@@ -48,28 +52,10 @@ async function main(): Promise<void> {
       }
       const rateLimitMax = limitArg
         ? parseInt(limitArg, 10)
-        : parseInt(process.env.QUILLBY_RATE_LIMIT ?? "60", 10);
-
-      const result = await auth.api.createApiKey({
-        body: {
-          userId,
-          name: keyName,
-          rateLimitEnabled: true,
-          rateLimitTimeWindow: 60_000, // 1 minute window
-          rateLimitMax,
-          // prefix makes keys identifiable in logs: "qb_<random>"
-          prefix: "qb",
-        },
-      });
-
+        : parseRateLimit(process.env.QUILLBY_RATE_LIMIT);
+      const result = await authApi.createApiKey(userId, keyName, rateLimitMax);
       console.log("Created API key (shown only once — save it now):");
-      console.log(
-        JSON.stringify(
-          { key: result.key, id: result.id, name: keyName, userId, rateLimitMax },
-          null,
-          2,
-        ),
-      );
+      console.log(JSON.stringify({ key: result.key, id: result.id, name: keyName, userId, rateLimitMax }, null, 2));
       break;
     }
 
@@ -79,7 +65,7 @@ async function main(): Promise<void> {
         console.error("Usage: manage-keys.ts list <userId>");
         process.exit(1);
       }
-      const keys = await auth.api.listApiKeys({ body: { userId } });
+      const keys = await listApiKeysFromDb(db, apikeyTable, userId);
       if (!keys || (Array.isArray(keys) && keys.length === 0)) {
         console.log("No keys found for user:", userId);
       } else {
@@ -94,7 +80,7 @@ async function main(): Promise<void> {
         console.error("Usage: manage-keys.ts revoke <keyId>");
         process.exit(1);
       }
-      await auth.api.deleteApiKey({ body: { keyId } });
+      await deleteApiKeyFromDb(db, apikeyTable, keyId);
       console.log(`Revoked key: ${keyId}`);
       break;
     }


### PR DESCRIPTION
## Summary

Extracts auth adapter code from `apps/mcp-server/` into a new `@quillby/auth` package (`packages/auth/`), and removes 4 empty stub packages.

## Changes

### New: `@quillby/auth` package
- `createAuth()` — better-auth instance factory accepting adapter, email service, rate limit, trusted origins
- `AuthApi` class — type-safe wrappers for `verifyApiKey`, `createApiKey`, `signUpEmail`, `getSession` (uses `auth.api`)
- `listApiKeysFromDb()` / `deleteApiKeyFromDb()` — drizzle-based helpers using `sql` template literals (bypasses better-auth's sessionMiddleware requirement)
- Shared types: `VerifiedApiKey`, `ListedApiKey`, `SerializedApiKey`
- Shared helpers: `parseRateLimit()`, `serializeApiKey()`

### Shell updates
- `apps/mcp-server/src/auth.ts` — simplified to 28 lines using `createAuth()` factory
- `apps/mcp-server/src/mcp/server.ts` — removed 60+ lines of inline auth wrappers (types, verifyApiKey, listApiKeys, createApiKey, deleteApiKey, serializeApiKey)
- `apps/mcp-server/src/cli/keys.ts` — uses `AuthApi` and drizzle-based helpers from `@quillby/auth`
- `tooling/scripts/manage-keys.ts` — same treatment (legacy CLI entry)
- Tests updated to import `parseRateLimit` from `@quillby/auth`

### Stub package removal
Removed 4 empty stub packages (README.md only, no package.json): `extractors`, `mcp-kit`, `observability`, `ui-contracts`

### Review fixes
- **Backward compat**: `listApiKeys`/`deleteApiKey` now use drizzle queries (better-auth's `auth.api` versions require browser session middleware)
- **`createdAt` consistency**: `SerializedApiKey.createdAt` uses `null` instead of `undefined` to match other nullable fields
- **No silent catches**: `AuthApi.getSession()` lets errors propagate to caller

## Verification
- `pnpm build` ✓
- `pnpm typecheck` (13/13 packages) ✓
- `pnpm test` (39 files, 436 tests) ✓
- `pnpm lint` (12/12 packages) ✓
- Pre-commit hooks (gitleaks, lint, typecheck) ✓

Closes REQ-000232 (monorepo extraction).