### PR TITLE
Wave 3: Password reset and email verification pages, Better Auth redirect config

### DIFF
--- a/apps/app/src/components/app/App.tsx
+++ b/apps/app/src/components/app/App.tsx
@@ -30,6 +30,9 @@ const Profile = lazyNamed(() => import("./pages/Profile"), "Profile");
 const Memory = lazyNamed(() => import("./pages/Memory"), "Memory");
 const Feeds = lazyNamed(() => import("./pages/Feeds"), "Feeds");
 const Connectors = lazyNamed(() => import("./pages/Connectors"), "Connectors");
+const ForgotPassword = lazyNamed(() => import("./pages/ForgotPassword"), "ForgotPassword");
+const ResetPassword = lazyNamed(() => import("./pages/ResetPassword"), "ResetPassword");
+const VerifyEmail = lazyNamed(() => import("./pages/VerifyEmail"), "VerifyEmail");
 
 class ErrorBoundary extends Component<
   { children: React.ReactNode },
@@ -199,6 +202,9 @@ export function App() {
               </RequireAuth>
             }
           />
+          {DEPLOY_MODE !== "self-hosted" && <Route path="/forgot-password" element={<LazyPage component={ForgotPassword} />} />}
+          {DEPLOY_MODE !== "self-hosted" && <Route path="/reset-password" element={<LazyPage component={ResetPassword} />} />}
+          {DEPLOY_MODE !== "self-hosted" && <Route path="/verify-email" element={<LazyPage component={VerifyEmail} />} />}
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
         </WorkspaceProvider>

--- a/apps/app/src/components/app/auth.ts
+++ b/apps/app/src/components/app/auth.ts
@@ -120,6 +120,27 @@ export async function revokeOtherSessions(): Promise<void> {
   });
 }
 
+export async function forgetPassword(email: string): Promise<void> {
+  await authFetch("/api/auth/forget-password", {
+    method: "POST",
+    body: JSON.stringify({ email }),
+  });
+}
+
+export async function resetPassword(newPassword: string, token: string): Promise<void> {
+  await authFetch("/api/auth/reset-password", {
+    method: "POST",
+    body: JSON.stringify({ newPassword, token }),
+  });
+}
+
+export async function verifyEmail(token: string): Promise<void> {
+  await authFetch("/api/auth/verify-email", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+}
+
 export function useSession() {
   const [data, setData] = useState<AppSession | null>(null);
   const [isPending, setIsPending] = useState(true);

--- a/apps/app/src/components/app/pages/Cloud.tsx
+++ b/apps/app/src/components/app/pages/Cloud.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Link, Navigate, useNavigate } from "react-router-dom";
 import { signInEmail, signUpEmail, useSession } from "../auth";
 import { Button, Spinner, Alert, Form, Input, Label, Tabs, TextField } from "@heroui/react";
 
@@ -144,6 +144,11 @@ export function Cloud() {
               <Label>Password</Label>
               <Input placeholder="••••••••" />
             </TextField>
+            {mode === "sign-in" && (
+              <Link to="/forgot-password" className="text-xs text-accent hover:underline self-end -mt-2">
+                Forgot password?
+              </Link>
+            )}
 
             {error && (
               <Alert status="danger">

--- a/apps/app/src/components/app/pages/ForgotPassword.tsx
+++ b/apps/app/src/components/app/pages/ForgotPassword.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Button, Alert, Form, Input, Label, TextField } from "@heroui/react";
+import { forgetPassword } from "../auth";
+
+export function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await forgetPassword(email);
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send reset email");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+        <div className="flex flex-col items-center gap-4 max-w-md w-full text-center">
+          <h1 className="text-2xl font-bold">Check your email</h1>
+          <p className="text-muted">
+            If an account exists for <strong>{email}</strong>, we've sent a password reset link.
+          </p>
+          <Button variant="ghost" onPress={() => setSent(false)}>
+            Send again
+          </Button>
+          <Link to="/cloud" className="text-sm text-accent hover:underline">Back to sign in</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+      <div className="flex flex-col gap-6 max-w-sm w-full">
+        <div>
+          <h1 className="text-2xl font-bold">Reset your password</h1>
+          <p className="text-sm text-muted mt-1">Enter your email and we'll send you a reset link.</p>
+        </div>
+
+        <Form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-4">
+          <TextField isRequired type="email" value={email} onChange={setEmail} name="email" className="w-full">
+            <Label>Email</Label>
+            <Input placeholder="you@example.com" />
+          </TextField>
+
+          {error && (
+            <Alert status="danger">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Description>{error}</Alert.Description>
+              </Alert.Content>
+            </Alert>
+          )}
+
+          <Button type="submit" variant="primary" isDisabled={loading} className="w-full justify-center">
+            {loading ? "Sending..." : "Send reset link"}
+          </Button>
+        </Form>
+
+        <Link to="/cloud" className="text-sm text-accent hover:underline text-center">Back to sign in</Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/app/pages/ResetPassword.tsx
+++ b/apps/app/src/components/app/pages/ResetPassword.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { useSearchParams, Link, useNavigate } from "react-router-dom";
+import { Button, Alert, Form, Input, Label, TextField } from "@heroui/react";
+import { resetPassword } from "../auth";
+
+export function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token") ?? "";
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <h1 className="text-2xl font-bold">Invalid reset link</h1>
+          <p className="text-muted">This reset link is missing a token. Please request a new one.</p>
+          <Link to="/forgot-password" className="text-sm text-accent hover:underline">Request new reset link</Link>
+        </div>
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirm) {
+      setError("Passwords do not match");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await resetPassword(password, token);
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to reset password");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <h1 className="text-2xl font-bold">Password reset</h1>
+          <p className="text-muted">Your password has been reset successfully.</p>
+          <Button variant="primary" onPress={() => navigate("/cloud")}>Sign in</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+      <div className="flex flex-col gap-6 max-w-sm w-full">
+        <div>
+          <h1 className="text-2xl font-bold">Set new password</h1>
+          <p className="text-sm text-muted mt-1">Enter your new password below.</p>
+        </div>
+
+        <Form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-4">
+          <TextField isRequired type="password" value={password} onChange={setPassword} name="password" className="w-full">
+            <Label>New password</Label>
+            <Input placeholder="••••••••" />
+          </TextField>
+
+          <TextField isRequired type="password" value={confirm} onChange={setConfirm} name="confirmPassword" className="w-full">
+            <Label>Confirm password</Label>
+            <Input placeholder="••••••••" />
+          </TextField>
+
+          {error && (
+            <Alert status="danger">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Description>{error}</Alert.Description>
+              </Alert.Content>
+            </Alert>
+          )}
+
+          <Button type="submit" variant="primary" isDisabled={loading} className="w-full justify-center">
+            {loading ? "Resetting..." : "Reset password"}
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/app/pages/VerifyEmail.tsx
+++ b/apps/app/src/components/app/pages/VerifyEmail.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useSearchParams, Link, useNavigate } from "react-router-dom";
+import { Button, Alert } from "@heroui/react";
+import { verifyEmail } from "../auth";
+
+type VerifyState = "loading" | "verified" | "error" | "no-token";
+
+export function VerifyEmail() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+  const [state, setState] = useState<VerifyState>(token ? "loading" : "no-token");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!token) return;
+    verifyEmail(token)
+      .then(() => setState("verified"))
+      .catch((err) => {
+        setMessage(err instanceof Error ? err.message : "Verification failed");
+        setState("error");
+      });
+  }, [token]);
+
+  if (state === "no-token") {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <h1 className="text-2xl font-bold">Invalid verification link</h1>
+          <p className="text-muted">This verification link is missing a token.</p>
+          <Link to="/cloud" className="text-sm text-accent hover:underline">Sign in</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+      <div className="flex flex-col items-center gap-4 max-w-md w-full text-center">
+        {state === "loading" && (
+          <>
+            <h1 className="text-2xl font-bold">Verifying your email...</h1>
+            <p className="text-muted">Please wait while we verify your email address.</p>
+          </>
+        )}
+
+        {state === "verified" && (
+          <>
+            <Alert status="success" className="w-full">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Description>Your email has been verified successfully.</Alert.Description>
+              </Alert.Content>
+            </Alert>
+            <Button variant="primary" onPress={() => navigate("/cloud")}>Sign in</Button>
+          </>
+        )}
+
+        {state === "error" && (
+          <>
+            <Alert status="danger" className="w-full">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Description>{message}</Alert.Description>
+              </Alert.Content>
+            </Alert>
+            <Link to="/cloud" className="text-sm text-accent hover:underline">Sign in</Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/mcp-server/src/auth.ts
+++ b/apps/mcp-server/src/auth.ts
@@ -9,6 +9,7 @@ const corsOrigin = process.env.QUILLBY_CORS_ORIGIN;
 const trustedOrigins = corsOrigin && corsOrigin !== "*"
   ? corsOrigin.split(",").map((o) => o.trim()).filter(Boolean)
   : [];
+const authBaseUrl = process.env.BETTER_AUTH_URL ?? undefined;
 
 export const auth = createAuth({
   database: drizzleAdapter(db, {
@@ -27,6 +28,7 @@ export const auth = createAuth({
   },
   rateLimitMax: parseRateLimit(process.env.QUILLBY_RATE_LIMIT),
   trustedOrigins,
+  baseUrl: authBaseUrl,
 });
 
 if (process.env.QUILLBY_SMTP_HOST) {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -73,10 +73,11 @@ export interface AuthConfig {
   emailAndPassword?: AuthEmailService;
   rateLimitMax?: number;
   trustedOrigins?: string[];
+  baseUrl?: string;
 }
 
 export function createAuth(config: AuthConfig): ReturnType<typeof betterAuth> {
-  const { database, emailAndPassword, rateLimitMax = 60, trustedOrigins = [] } = config;
+  const { database, emailAndPassword, rateLimitMax = 60, trustedOrigins = [], baseUrl } = config;
 
   const apiKeyPlugin = apiKey({
     enableSessionForAPIKeys: false,
@@ -89,6 +90,7 @@ export function createAuth(config: AuthConfig): ReturnType<typeof betterAuth> {
 
   const opts: Record<string, unknown> = {
     database,
+    baseURL: baseUrl,
     plugins: [apiKeyPlugin],
   };
 
@@ -98,6 +100,11 @@ export function createAuth(config: AuthConfig): ReturnType<typeof betterAuth> {
       sendEmailVerification: true,
       sendVerificationEmail: emailAndPassword.sendVerificationEmail,
       sendResetPassword: emailAndPassword.sendResetPassword,
+    };
+    opts.emailVerification = {
+      sendOnSignUp: true,
+      autoSignInAfterVerification: true,
+      redirectTo: baseUrl,
     };
   }
 


### PR DESCRIPTION
## Summary

2 production readiness tasks.

| Task | Change |
|------|--------|
| T-000567 | HeroUIProvider — no-op for v3 (Tailwind dark class is correct, no global provider needed) |
| T-000568 | 3 new auth pages + Better Auth redirect configuration |

## New pages

- **ForgotPassword** — email form → POST `/api/auth/forget-password` → success state with re-send
- **ResetPassword** — reads `?token=` → password + confirm form → POST `/api/auth/reset-password` → success
- **VerifyEmail** — reads `?token=` → POST `/api/auth/verify-email` → verified/error states

## Review findings addressed

- `credentials: "include"` — all pages use `authFetch()` wrapper via auth.ts
- Auth routes gated with `DEPLOY_MODE !== "self-hosted"`
- Better Auth redirect config: `baseURL`, `redirectTo`, `autoSignInAfterVerification`
- `forgetPassword`, `resetPassword`, `verifyEmail` wrappers added to `auth.ts`
- "Forgot password?" link on Cloud.tsx sign-in form

## Verification

445/445 tests pass. Typecheck clean. SPA builds clean (2.15-2.96 kB lazy chunks).