### PR TITLE
Wave 4: ESLint architecture boundary, SPA foundation (ToastProvider, per-route ErrorBoundary, ConfirmDialog)

### DIFF
--- a/apps/app/src/components/app/App.tsx
+++ b/apps/app/src/components/app/App.tsx
@@ -1,6 +1,7 @@
-import React, { Component, lazy, Suspense } from "react";
+import React, { lazy, Suspense } from "react";
 import { HashRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
-import { Button, Alert } from "@heroui/react";
+import { ToastProvider } from "@heroui/react";
+import { ErrorBoundary } from "./ErrorBoundary";
 import { useSession } from "./auth";
 import { getConnection } from "./api";
 import { WorkspaceProvider } from "./WorkspaceContext";
@@ -34,50 +35,6 @@ const ForgotPassword = lazyNamed(() => import("./pages/ForgotPassword"), "Forgot
 const ResetPassword = lazyNamed(() => import("./pages/ResetPassword"), "ResetPassword");
 const VerifyEmail = lazyNamed(() => import("./pages/VerifyEmail"), "VerifyEmail");
 
-class ErrorBoundary extends Component<
-  { children: React.ReactNode },
-  { error: Error | null }
-> {
-  constructor(props: { children: React.ReactNode }) {
-    super(props);
-    this.state = { error: null };
-  }
-  static getDerivedStateFromError(error: Error) {
-    return { error };
-  }
-  handleRetry = () => {
-    this.setState({ error: null });
-  };
-  render() {
-    if (this.state.error) {
-      const isChunkError = this.state.error.message?.includes("dynamically imported");
-      return (
-        <div className="min-h-screen flex items-center justify-center p-8 bg-background">
-          <div className="flex flex-col items-center gap-4 max-w-lg w-full">
-            <Alert status="danger" className="w-full">
-              <Alert.Indicator />
-              <Alert.Content>
-                <Alert.Title>
-                  {isChunkError ? "Failed to load page" : "App Error"}
-                </Alert.Title>
-                <Alert.Description>
-                  {isChunkError
-                    ? "A network error occurred while loading this page."
-                    : this.state.error.message}
-                </Alert.Description>
-              </Alert.Content>
-            </Alert>
-            <Button variant="ghost" onPress={this.handleRetry}>
-              Try Again
-            </Button>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
-
 const DEPLOY_MODE = (import.meta.env.VITE_QUILLBY_DEPLOYMENT_MODE ?? "").trim().toLowerCase();
 
 function CloudRequireAuth({ children }: { children: React.ReactNode }) {
@@ -106,15 +63,17 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
 
 function LazyPage({ component: Component }: { component: React.LazyExoticComponent<React.ComponentType> }) {
   return (
-    <Suspense fallback={<PageSkeleton />}>
-      <Component />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense fallback={<PageSkeleton />}>
+        <Component />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 
 export function App() {
   return (
-    <ErrorBoundary>
+    <ToastProvider>
       <HashRouter>
         <WorkspaceProvider>
         <Routes>
@@ -209,6 +168,6 @@ export function App() {
         </Routes>
         </WorkspaceProvider>
       </HashRouter>
-    </ErrorBoundary>
+      </ToastProvider>
   );
 }

--- a/apps/app/src/components/app/ConfirmDialog.tsx
+++ b/apps/app/src/components/app/ConfirmDialog.tsx
@@ -1,0 +1,45 @@
+import { AlertDialog, Button } from "@heroui/react";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "danger" | "primary";
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "danger",
+  onConfirm,
+  onCancel,
+  loading = false,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog isOpen={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel(); }}>
+      <AlertDialog.Backdrop />
+      <AlertDialog.Dialog>
+        <AlertDialog.Header>
+          <AlertDialog.Heading>{title}</AlertDialog.Heading>
+        </AlertDialog.Header>
+        <AlertDialog.Body>
+          <p className="text-muted text-sm">{description}</p>
+        </AlertDialog.Body>
+        <AlertDialog.Footer>
+          <Button variant="ghost" onPress={onCancel} isDisabled={loading}>{cancelLabel}</Button>
+          <Button variant={variant === "danger" ? "danger" : "primary"} onPress={onConfirm} isDisabled={loading}>
+            {loading ? "Processing..." : confirmLabel}
+          </Button>
+        </AlertDialog.Footer>
+      </AlertDialog.Dialog>
+    </AlertDialog>
+  );
+}

--- a/apps/app/src/components/app/ErrorBoundary.tsx
+++ b/apps/app/src/components/app/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import React, { Component } from "react";
+import { Button, Alert } from "@heroui/react";
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  handleRetry = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) return this.props.fallback;
+
+      const isChunkError = this.state.error.message?.includes("dynamically imported");
+      return (
+        <div className="min-h-screen flex items-center justify-center p-8 bg-background">
+          <div className="flex flex-col items-center gap-4 max-w-lg w-full">
+            <Alert status="danger" className="w-full">
+              <Alert.Indicator />
+              <Alert.Content>
+                <Alert.Title>
+                  {isChunkError ? "Failed to load page" : "App Error"}
+                </Alert.Title>
+                <Alert.Description>
+                  {isChunkError
+                    ? "A network error occurred while loading this page."
+                    : this.state.error.message}
+                </Alert.Description>
+              </Alert.Content>
+            </Alert>
+            <Button variant="ghost" onPress={this.handleRetry}>
+              Try Again
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,4 +56,31 @@ export default tseslint.config(
       globals: sharedGlobals,
     },
   },
+  // ── Architecture boundary: core packages must not import framework packages ──
+  {
+    files: ["packages/*/src/**/*.{js,ts,jsx,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@modelcontextprotocol/sdk",
+              message: "Core packages must not import MCP SDK types. Map at the boundary in apps/mcp-server.",
+            },
+            {
+              name: "@modelcontextprotocol/sdk/server/index.js",
+              message: "Core packages must not import MCP SDK types. Map at the boundary in apps/mcp-server.",
+            },
+          ],
+          patterns: [
+            {
+              group: ["@heroui/*"],
+              message: "Core packages must not import HeroUI components. React UI belongs in apps/app.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/packages/providers/src/sampling.ts
+++ b/packages/providers/src/sampling.ts
@@ -1,9 +1,20 @@
-import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { ProviderAdapter, GenerationRequest, GenerationResult } from "./router.js";
 import type { GenerationModality } from "@quillby/core";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
+
+/**
+ * Minimal interface for MCP sampling capability.
+ * Avoids importing the full MCP SDK Server type.
+ */
+interface SamplingHost {
+  createMessage(params: {
+    messages: { role: string; content: { type: string; text: string } }[];
+    systemPrompt?: string;
+    maxTokens?: number;
+  }): Promise<{ content?: unknown }>;
+}
 
 const SUPPORTED: GenerationModality[] = ["image", "audio"];
 
@@ -23,7 +34,7 @@ export class McpSamplingAdapter implements ProviderAdapter {
   readonly supportedModalities: GenerationModality[] = SUPPORTED;
 
   constructor(
-    private readonly server: Server,
+    private readonly server: SamplingHost,
     private readonly outputDir: string
   ) {}
 


### PR DESCRIPTION
## Summary

4 production readiness tasks.

| Task | Change |
|------|--------|
| T-000554 | ESLint `no-restricted-imports` rule for `@modelcontextprotocol/sdk` + `@heroui/*` in core packages |
| T-000583 | `ToastProvider` wrapping in SPA root |
| T-000585 | Extracted `ErrorBoundary` to standalone component + per-route boundaries |
| T-000586 | `ConfirmDialog` component wrapping HeroUI `AlertDialog` |

## Key changes

- **Architecture enforcement**: New ESLint rule catches framework leaks into core packages. Fixed `packages/providers/src/sampling.ts` — replaced MCP SDK `Server` type import with local `SamplingHost` interface.
- **Toast system**: `<ToastProvider>` wraps the entire SPA, enabling `toast()` from any page component.
- **Per-route error boundaries**: Each lazy-loaded page has its own `<ErrorBoundary>`. A crash in one page (e.g., Settings) no longer takes down the entire SPA.
- **ConfirmDialog**: Reusable `ConfirmDialog` component with danger/primary variants, loading state, and accessible AlertDialog semantics.

## Verification

- `pnpm lint --force` — all 12 packages pass
- SPA builds clean
- 445/445 unit tests pass