### PR TITLE
Wave 7b: Extend ToolStorage interface for content handler extraction

### DIFF
--- a/apps/mcp-server/src/mcp/tools/index.ts
+++ b/apps/mcp-server/src/mcp/tools/index.ts
@@ -26,6 +26,14 @@ export interface ToolStorage {
   updateWorkspaceMetadata(meta: Record<string, unknown>): Promise<{ id: string; [key: string]: unknown }>;
   latestHarvestExists(): Promise<boolean>;
   loadLatestHarvest(): Promise<Record<string, unknown> | null>;
+  saveHarvestOutput(cards: unknown[], seenUrls: Set<string>): Promise<string>;
+  saveSeenUrls(urls: Set<string>): Promise<void>;
+  getSeenUrls(): Promise<Set<string>>;
+  saveDraft(content: string, platform: string, cardId?: number): Promise<string>;
+  listDrafts(): Promise<unknown[]>;
+  saveCurationState(state: Record<string, "shortlisted" | "skipped">): Promise<void>;
+  appendTypedMemory(type: string, entries: string[], maxItems?: number): Promise<void>;
+  getPlan(): Promise<string>;
 }
 
 export type ToolResult = {


### PR DESCRIPTION
## Summary

Prepares the ToolStorage interface for future content handler extraction.

- Extended  in  with 8 missing methods: , , , , , , , 
- Tool definition extraction was completed in PR #25 (Wave 7a)
- Handler extraction deferred due to pervasive type mismatches between ToolStorage and WorkspaceStorage

## Verification

445/445 tests pass. Lint + typecheck pass all 13 packages.