### PR TITLE
feat: add comprehensive test coverage for content, storage-fs, and storage-db

### DIFF
--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -14,7 +14,13 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:unit": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
   },
   "dependencies": {
     "zod": "^3.24.0"

--- a/packages/content/src/campaign/pipeline.ts
+++ b/packages/content/src/campaign/pipeline.ts
@@ -24,9 +24,10 @@ export function transitionStage(
     updatedExecution,
   ];
 
-  const allCompleted = executions
-    .filter((e) => campaign.stages.some((s) => s.name === e.stageName))
-    .every((e) => e.status === "completed" || e.status === "skipped");
+  const allCompleted = campaign.stages.every((s) => {
+    const ex = executions.find((e) => e.stageName === s.name);
+    return ex && (ex.status === "completed" || ex.status === "skipped");
+  });
 
   const anyFailed = executions.some((e) => e.status === "failed");
 

--- a/packages/content/tests/campaign.test.ts
+++ b/packages/content/tests/campaign.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import type { Campaign, StageConfig } from "../src/index.js";
+import {
+  CampaignStatusSchema,
+  StageStatusSchema,
+  StageConfigSchema,
+  BlueprintSchema,
+  ExecutionLogSchema,
+  CampaignSchema,
+  transitionStage,
+  areDependenciesMet,
+  getNextStages,
+  checkAllCompleted,
+  canRetryStage,
+  initialExecutionLogs,
+} from "../src/index.js";
+
+describe("CampaignStatusSchema", () => {
+  it("accepts valid statuses", () => {
+    expect(CampaignStatusSchema.parse("planning")).toBe("planning");
+    expect(CampaignStatusSchema.parse("active")).toBe("active");
+    expect(CampaignStatusSchema.parse("paused")).toBe("paused");
+    expect(CampaignStatusSchema.parse("completed")).toBe("completed");
+    expect(CampaignStatusSchema.parse("failed")).toBe("failed");
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => CampaignStatusSchema.parse("unknown")).toThrow();
+  });
+});
+
+describe("StageStatusSchema", () => {
+  it("accepts valid statuses", () => {
+    expect(StageStatusSchema.parse("pending")).toBe("pending");
+    expect(StageStatusSchema.parse("running")).toBe("running");
+    expect(StageStatusSchema.parse("completed")).toBe("completed");
+    expect(StageStatusSchema.parse("failed")).toBe("failed");
+    expect(StageStatusSchema.parse("skipped")).toBe("skipped");
+  });
+});
+
+describe("StageConfigSchema", () => {
+  it("validates a stage config with defaults", () => {
+    const result = StageConfigSchema.parse({
+      name: "Research",
+      tool: "research_agent",
+    });
+    expect(result.params).toEqual({});
+    expect(result.dependsOn).toEqual([]);
+    expect(result.retryCount).toBe(0);
+  });
+
+  it("rejects empty name", () => {
+    expect(() => StageConfigSchema.parse({ name: "", tool: "x" })).toThrow();
+  });
+});
+
+describe("BlueprintSchema", () => {
+  it("validates a blueprint with defaults", () => {
+    const now = new Date().toISOString();
+    const result = BlueprintSchema.parse({
+      id: "bp-1",
+      name: "Weekly Content",
+      stages: [{ name: "Research", tool: "research_agent" }],
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(result.description).toBe("");
+    expect(result.tags).toEqual([]);
+  });
+});
+
+describe("ExecutionLogSchema", () => {
+  it("validates an execution log with defaults", () => {
+    const result = ExecutionLogSchema.parse({
+      stageName: "Research",
+      status: "pending",
+    });
+    expect(result.retryAttempt).toBe(0);
+  });
+
+  it("validates a complete execution log", () => {
+    const result = ExecutionLogSchema.parse({
+      stageName: "Research",
+      status: "failed",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      completedAt: "2026-06-01T01:00:00.000Z",
+      error: "Timeout",
+      result: { reason: "API down" },
+      retryAttempt: 2,
+    });
+    expect(result.error).toBe("Timeout");
+    expect(result.retryAttempt).toBe(2);
+  });
+});
+
+describe("CampaignSchema", () => {
+  it("validates a minimal campaign with defaults", () => {
+    const now = new Date().toISOString();
+    const result = CampaignSchema.parse({
+      id: "camp-1",
+      workspaceId: "ws-1",
+      name: "Launch",
+      status: "planning",
+      stages: [{ name: "Research", tool: "research_agent" }],
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(result.executions).toEqual([]);
+    expect(result.blueprintId).toBe("");
+  });
+});
+
+const makeStage = (name: string, overrides?: Partial<StageConfig>): StageConfig => ({
+  name,
+  tool: `${name}_tool`,
+  params: {},
+  dependsOn: overrides?.dependsOn ?? [],
+  condition: undefined,
+  retryCount: overrides?.retryCount ?? 0,
+  timeout: undefined,
+});
+
+const makeCampaign = (overrides?: Partial<Campaign>): Campaign => {
+  const now = "2026-06-01T00:00:00.000Z";
+  return {
+    id: "camp-1",
+    workspaceId: "ws-1",
+    blueprintId: "",
+    name: "Test Campaign",
+    status: "active",
+    stages: [],
+    executions: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+describe("initialExecutionLogs", () => {
+  it("creates pending logs for each stage", () => {
+    const stages = [makeStage("Research"), makeStage("Write")];
+    const logs = initialExecutionLogs(stages);
+    expect(logs).toHaveLength(2);
+    expect(logs[0].status).toBe("pending");
+    expect(logs[0].retryAttempt).toBe(0);
+  });
+});
+
+describe("areDependenciesMet", () => {
+  it("returns true when no dependencies", () => {
+    const stage = makeStage("Research");
+    const campaign = makeCampaign();
+    expect(areDependenciesMet(stage, campaign)).toBe(true);
+  });
+
+  it("returns true when all dependencies completed", () => {
+    const stage = makeStage("Write", { dependsOn: ["Research"] });
+    const campaign = makeCampaign({
+      executions: [{ stageName: "Research", status: "completed", retryAttempt: 0 }],
+    });
+    expect(areDependenciesMet(stage, campaign)).toBe(true);
+  });
+
+  it("returns true when dependency skipped", () => {
+    const stage = makeStage("Write", { dependsOn: ["Research"] });
+    const campaign = makeCampaign({
+      executions: [{ stageName: "Research", status: "skipped", retryAttempt: 0 }],
+    });
+    expect(areDependenciesMet(stage, campaign)).toBe(true);
+  });
+
+  it("returns false when dependency not started", () => {
+    const stage = makeStage("Write", { dependsOn: ["Research"] });
+    const campaign = makeCampaign();
+    expect(areDependenciesMet(stage, campaign)).toBe(false);
+  });
+
+  it("returns false when dependency failed", () => {
+    const stage = makeStage("Write", { dependsOn: ["Research"] });
+    const campaign = makeCampaign({
+      executions: [{ stageName: "Research", status: "failed", retryAttempt: 0 }],
+    });
+    expect(areDependenciesMet(stage, campaign)).toBe(false);
+  });
+});
+
+describe("transitionStage", () => {
+  it("transitions a stage to running", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research")],
+      executions: [{ stageName: "Research", status: "pending", retryAttempt: 0 }],
+    });
+    const result = transitionStage(campaign, "Research", "running");
+    expect(result.executions[0].status).toBe("running");
+    expect(result.executions[0].startedAt).toBeDefined();
+    expect(result.startedAt).toBeDefined();
+  });
+
+  it("transitions a stage to completed", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research")],
+      executions: [{ stageName: "Research", status: "running", retryAttempt: 0 }],
+    });
+    const result = transitionStage(campaign, "Research", "completed");
+    expect(result.executions[0].status).toBe("completed");
+    expect(result.executions[0].completedAt).toBeDefined();
+    expect(result.status).toBe("completed");
+  });
+
+  it("marks campaign as failed on stage failure", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research")],
+      executions: [{ stageName: "Research", status: "running", retryAttempt: 0 }],
+    });
+    const result = transitionStage(campaign, "Research", "failed", { error: "Something broke" });
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("Something broke");
+  });
+
+  it("preserves existing retry attempt", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research", { retryCount: 2 })],
+      executions: [{ stageName: "Research", status: "failed", retryAttempt: 1 }],
+    });
+    const result = transitionStage(campaign, "Research", "running");
+    expect(result.executions[0].retryAttempt).toBe(1);
+  });
+
+  it("campaign stays active when some stages remain", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research"), makeStage("Write")],
+      executions: [{ stageName: "Research", status: "completed", retryAttempt: 0 }],
+    });
+    const result = transitionStage(campaign, "Research", "completed");
+    expect(result.status).toBe("active");
+  });
+});
+
+describe("getNextStages", () => {
+  it("returns all stages when none started", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research"), makeStage("Write")],
+    });
+    const next = getNextStages(campaign);
+    expect(next).toHaveLength(2);
+  });
+
+  it("returns only stages with met dependencies", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research"), makeStage("Write", { dependsOn: ["Research"] })],
+    });
+    const next = getNextStages(campaign);
+    expect(next).toHaveLength(1);
+    expect(next[0].name).toBe("Research");
+  });
+
+  it("does not return already started or failed stages", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research"), makeStage("Write", { dependsOn: ["Research"] })],
+      executions: [
+        { stageName: "Research", status: "completed", retryAttempt: 0 },
+      ],
+    });
+    const next = getNextStages(campaign);
+    expect(next).toHaveLength(1);
+    expect(next[0].name).toBe("Write");
+  });
+
+  it("excludes failed stages", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research"), makeStage("Write")],
+      executions: [{ stageName: "Research", status: "failed", retryAttempt: 0 }],
+    });
+    const next = getNextStages(campaign);
+    expect(next.every((s) => s.name !== "Research")).toBe(true);
+  });
+});
+
+describe("checkAllCompleted", () => {
+  it("returns true when all stages done or skipped", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research"), makeStage("Write")],
+      executions: [
+        { stageName: "Research", status: "completed", retryAttempt: 0 },
+        { stageName: "Write", status: "skipped", retryAttempt: 0 },
+      ],
+    });
+    expect(checkAllCompleted(campaign)).toBe(true);
+  });
+
+  it("returns false when a stage is still pending", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research")],
+      executions: [{ stageName: "Research", status: "pending", retryAttempt: 0 }],
+    });
+    expect(checkAllCompleted(campaign)).toBe(false);
+  });
+});
+
+describe("canRetryStage", () => {
+  it("returns true when stage failed and retries remain", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research", { retryCount: 3 })],
+      executions: [{ stageName: "Research", status: "failed", retryAttempt: 1 }],
+    });
+    expect(canRetryStage(campaign, "Research")).toBe(true);
+  });
+
+  it("returns false when retries exhausted", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research", { retryCount: 1 })],
+      executions: [{ stageName: "Research", status: "failed", retryAttempt: 1 }],
+    });
+    expect(canRetryStage(campaign, "Research")).toBe(false);
+  });
+
+  it("returns false when stage not found", () => {
+    const campaign = makeCampaign();
+    expect(canRetryStage(campaign, "Nonexistent")).toBe(false);
+  });
+
+  it("returns false when stage has no execution", () => {
+    const campaign = makeCampaign({
+      stages: [makeStage("Research")],
+    });
+    expect(canRetryStage(campaign, "Research")).toBe(false);
+  });
+});

--- a/packages/content/tests/plan.test.ts
+++ b/packages/content/tests/plan.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  ContentTaskTypeSchema,
+  ContentTaskPrioritySchema,
+  ContentTaskStatusSchema,
+  ContentTaskSchema,
+  CalendarEntrySchema,
+  ContentPlanStatusSchema,
+  ContentPlanSchema,
+} from "../src/index.js";
+
+describe("ContentTaskTypeSchema", () => {
+  it("accepts valid task types", () => {
+    expect(ContentTaskTypeSchema.parse("compose")).toBe("compose");
+    expect(ContentTaskTypeSchema.parse("curate")).toBe("curate");
+    expect(ContentTaskTypeSchema.parse("review")).toBe("review");
+    expect(ContentTaskTypeSchema.parse("research")).toBe("research");
+    expect(ContentTaskTypeSchema.parse("publish")).toBe("publish");
+    expect(ContentTaskTypeSchema.parse("design")).toBe("design");
+    expect(ContentTaskTypeSchema.parse("other")).toBe("other");
+  });
+
+  it("rejects invalid task type", () => {
+    expect(() => ContentTaskTypeSchema.parse("invalid")).toThrow();
+  });
+});
+
+describe("ContentTaskPrioritySchema", () => {
+  it("accepts valid priorities", () => {
+    expect(ContentTaskPrioritySchema.parse("p1")).toBe("p1");
+    expect(ContentTaskPrioritySchema.parse("p2")).toBe("p2");
+    expect(ContentTaskPrioritySchema.parse("p3")).toBe("p3");
+  });
+
+  it("rejects invalid priority", () => {
+    expect(() => ContentTaskPrioritySchema.parse("p4")).toThrow();
+  });
+});
+
+describe("ContentTaskStatusSchema", () => {
+  it("accepts valid statuses", () => {
+    expect(ContentTaskStatusSchema.parse("todo")).toBe("todo");
+    expect(ContentTaskStatusSchema.parse("doing")).toBe("doing");
+    expect(ContentTaskStatusSchema.parse("review")).toBe("review");
+    expect(ContentTaskStatusSchema.parse("done")).toBe("done");
+    expect(ContentTaskStatusSchema.parse("cancelled")).toBe("cancelled");
+  });
+});
+
+describe("ContentTaskSchema", () => {
+  it("validates a complete task", () => {
+    const result = ContentTaskSchema.parse({
+      id: "task-1",
+      planId: "plan-1",
+      title: "Write post",
+      type: "compose",
+      priority: "p1",
+      status: "todo",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    expect(result.title).toBe("Write post");
+    expect(result.type).toBe("compose");
+  });
+
+  it("accepts optional fields", () => {
+    const result = ContentTaskSchema.parse({
+      id: "task-2",
+      planId: "plan-1",
+      title: "Review",
+      type: "review",
+      priority: "p2",
+      status: "doing",
+      actor: "Alice",
+      platform: "linkedin",
+      description: "Check for tone",
+      dueDate: "2026-06-15",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    expect(result.actor).toBe("Alice");
+    expect(result.dueDate).toBe("2026-06-15");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => ContentTaskSchema.parse({})).toThrow();
+  });
+});
+
+describe("CalendarEntrySchema", () => {
+  it("validates a calendar entry with tasks", () => {
+    const result = CalendarEntrySchema.parse({
+      date: "2026-06-15",
+      tasks: [{ taskId: "t-1", planId: "p-1" }],
+    });
+    expect(result.tasks).toHaveLength(1);
+  });
+
+  it("rejects missing date", () => {
+    expect(() => CalendarEntrySchema.parse({})).toThrow();
+  });
+});
+
+describe("ContentPlanStatusSchema", () => {
+  it("accepts valid statuses", () => {
+    expect(ContentPlanStatusSchema.parse("active")).toBe("active");
+    expect(ContentPlanStatusSchema.parse("completed")).toBe("completed");
+    expect(ContentPlanStatusSchema.parse("archived")).toBe("archived");
+  });
+});
+
+describe("ContentPlanSchema", () => {
+  it("validates a minimal plan with defaults", () => {
+    const result = ContentPlanSchema.parse({
+      id: "plan-1",
+      name: "Weekly Newsletter",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    expect(result.status).toBe("active");
+    expect(result.description).toBe("");
+    expect(result.tags).toEqual([]);
+  });
+
+  it("validates a complete plan", () => {
+    const result = ContentPlanSchema.parse({
+      id: "plan-1",
+      name: "Campaign",
+      description: "Q3 launch",
+      dateStart: "2026-07-01",
+      dateEnd: "2026-09-30",
+      status: "active",
+      tags: ["launch", "q3"],
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+    expect(result.tags).toEqual(["launch", "q3"]);
+  });
+});

--- a/packages/content/tests/session.test.ts
+++ b/packages/content/tests/session.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  SessionScopeTypeSchema,
+  SessionScopeSchema,
+  SessionStateSchema,
+  DegradationInfoSchema,
+  SessionSchema,
+} from "../src/index.js";
+
+describe("SessionScopeTypeSchema", () => {
+  it("accepts valid scope types", () => {
+    expect(SessionScopeTypeSchema.parse("campaign")).toBe("campaign");
+    expect(SessionScopeTypeSchema.parse("plan")).toBe("plan");
+    expect(SessionScopeTypeSchema.parse("task")).toBe("task");
+    expect(SessionScopeTypeSchema.parse("freeform")).toBe("freeform");
+  });
+
+  it("rejects invalid scope type", () => {
+    expect(() => SessionScopeTypeSchema.parse("invalid")).toThrow();
+  });
+});
+
+describe("SessionScopeSchema", () => {
+  it("validates a scope with defaults", () => {
+    const result = SessionScopeSchema.parse({
+      type: "freeform",
+      goal: "Review content",
+    });
+    expect(result.constraints).toEqual([]);
+  });
+
+  it("accepts a campaign-scoped session", () => {
+    const result = SessionScopeSchema.parse({
+      type: "campaign",
+      goal: "Launch campaign",
+      campaignId: "camp-1",
+    });
+    expect(result.campaignId).toBe("camp-1");
+  });
+});
+
+describe("SessionStateSchema", () => {
+  it("accepts valid states", () => {
+    expect(SessionStateSchema.parse("planning")).toBe("planning");
+    expect(SessionStateSchema.parse("executing")).toBe("executing");
+    expect(SessionStateSchema.parse("reviewing")).toBe("reviewing");
+    expect(SessionStateSchema.parse("closing")).toBe("closing");
+  });
+});
+
+describe("DegradationInfoSchema", () => {
+  it("provides empty defaults", () => {
+    const result = DegradationInfoSchema.parse({});
+    expect(result.warnings).toEqual([]);
+    expect(result.tokenBudget).toBeUndefined();
+  });
+});
+
+describe("SessionSchema", () => {
+  it("validates a complete session", () => {
+    const result = SessionSchema.parse({
+      id: "sess-1",
+      workspaceId: "ws-1",
+      scope: { type: "freeform", goal: "Draft posts" },
+      state: "executing",
+      startedAt: "2026-06-01T00:00:00.000Z",
+      lastActivityAt: "2026-06-01T01:00:00.000Z",
+    });
+    expect(result.state).toBe("executing");
+    expect(result.degradation.warnings).toEqual([]);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => SessionSchema.parse({})).toThrow();
+  });
+});

--- a/packages/content/vitest.config.ts
+++ b/packages/content/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      thresholds: {
+        statements: 85,
+        branches: 65,
+        functions: 80,
+        lines: 85,
+      },
+    },
+  },
+});

--- a/packages/storage-db/package.json
+++ b/packages/storage-db/package.json
@@ -14,7 +14,13 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:unit": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
   },
   "dependencies": {
     "@quillby/billing": "workspace:*",

--- a/packages/storage-db/tests/storage-db-plans.test.ts
+++ b/packages/storage-db/tests/storage-db-plans.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ContentPlan } from "@quillby/content";
+import { createDb } from "@quillby/database";
+import { HostedDbWorkspaceStorage } from "../src/index.js";
+
+let tempDir = "";
+let tempDbPath = "";
+
+function makeStorage(userId = "test-user"): HostedDbWorkspaceStorage {
+  const { db } = createDb(`file:${tempDbPath}`);
+  return new HostedDbWorkspaceStorage(userId, db);
+}
+
+async function withWorkspace(storage: HostedDbWorkspaceStorage): Promise<string> {
+  await storage.createWorkspace({ name: "Test", id: "test-ws", makeCurrent: true });
+  return "test-ws";
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-db-plans-"));
+  tempDbPath = path.join(tempDir, "test.db");
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+const now = () => new Date().toISOString();
+const plan = (id: string, overrides?: Partial<ContentPlan>) => ({
+  id,
+  name: `Plan ${id}`,
+  description: "",
+  status: "active" as const,
+  tags: [] as string[],
+  createdAt: now(),
+  updatedAt: now(),
+  ...overrides,
+});
+const task = (id: string, planId: string, overrides?: Partial<Parameters<HostedDbWorkspaceStorage["createTask"]>[0]>) => ({
+  id,
+  planId,
+  title: `Task ${id}`,
+  type: "compose" as const,
+  priority: "p2" as const,
+  status: "todo" as const,
+  createdAt: now(),
+  updatedAt: now(),
+  ...overrides,
+});
+
+describe("HostedDbWorkspaceStorage — PlanStorage", () => {
+  describe("createPlan", () => {
+    it("inserts and retrieves a plan", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      await storage.createPlan(plan("plan-1"));
+      const loaded = await storage.loadPlan("plan-1");
+      expect(loaded).not.toBeNull();
+      expect(loaded!.name).toBe("Plan plan-1");
+    });
+  });
+
+  describe("loadPlan", () => {
+    it("returns null for missing plan", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const result = await storage.loadPlan("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("listPlans", () => {
+    it("returns all plans", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.createPlan(plan("p2", { createdAt: ts, updatedAt: ts }));
+      const plans = await storage.listPlans();
+      expect(plans).toHaveLength(2);
+    });
+
+    it("filters by status", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { status: "active", createdAt: ts, updatedAt: ts }));
+      await storage.createPlan(plan("p2", { status: "completed", createdAt: ts, updatedAt: ts }));
+      const active = await storage.listPlans("active");
+      expect(active).toHaveLength(1);
+      expect(active[0]!.id).toBe("p1");
+    });
+  });
+
+  describe("updatePlan", () => {
+    it("updates name and status", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.updatePlan("p1", { name: "Updated", status: "completed" });
+      const loaded = await storage.loadPlan("p1");
+      expect(loaded!.name).toBe("Updated");
+      expect(loaded!.status).toBe("completed");
+    });
+
+    it("throws on missing plan", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      await expect(storage.updatePlan("nonexistent", { name: "X" })).rejects.toThrow("not found");
+    });
+  });
+
+  describe("deletePlan", () => {
+    it("deletes plan and its tasks", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.createTask(task("t1", "p1"));
+      await storage.deletePlan("p1");
+      expect(await storage.loadPlan("p1")).toBeNull();
+      expect(await storage.loadTask("t1")).toBeNull();
+    });
+  });
+});
+
+describe("HostedDbWorkspaceStorage — Tasks", () => {
+  describe("createTask", () => {
+    it("inserts a task linked to a plan", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.createTask(task("t1", "p1"));
+      const loaded = await storage.loadTask("t1");
+      expect(loaded).not.toBeNull();
+      expect(loaded!.title).toBe("Task t1");
+    });
+  });
+
+  describe("listTasks", () => {
+    it("returns all tasks for a plan", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.createTask(task("t1", "p1"));
+      await storage.createTask(task("t2", "p1"));
+      const tasks = await storage.listTasks("p1");
+      expect(tasks).toHaveLength(2);
+    });
+  });
+
+  describe("updateTask", () => {
+    it("updates task status", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.createTask(task("t1", "p1"));
+      await storage.updateTask("t1", { status: "doing" });
+      const loaded = await storage.loadTask("t1");
+      expect(loaded!.status).toBe("doing");
+    });
+  });
+
+  describe("deleteTask", () => {
+    it("deletes a task", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const ts = now();
+      await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+      await storage.createTask(task("t1", "p1"));
+      await storage.deleteTask("t1");
+      expect(await storage.loadTask("t1")).toBeNull();
+    });
+  });
+});
+
+describe("HostedDbWorkspaceStorage — getTodayQueue", () => {
+  it("includes tasks without dueDate", async () => {
+    const storage = makeStorage();
+    await withWorkspace(storage);
+    const ts = now();
+    await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+    await storage.createTask(task("t1", "p1"));
+    const queue = await storage.getTodayQueue();
+    expect(queue).toHaveLength(1);
+  });
+
+  it("excludes done tasks", async () => {
+    const storage = makeStorage();
+    await withWorkspace(storage);
+    const ts = now();
+    await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+    await storage.createTask(task("t1", "p1", { status: "done" }));
+    const queue = await storage.getTodayQueue();
+    expect(queue).toHaveLength(0);
+  });
+});
+
+describe("HostedDbWorkspaceStorage — getCalendar", () => {
+  it("returns tasks grouped by date within range", async () => {
+    const storage = makeStorage();
+    await withWorkspace(storage);
+    const ts = now();
+    await storage.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+    await storage.createTask(task("t1", "p1", { dueDate: "2026-06-15" }));
+    await storage.createTask(task("t2", "p1", { dueDate: "2026-06-15" }));
+    const entries = await storage.getCalendar("2026-06-01", "2026-06-30");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.tasks).toHaveLength(2);
+  });
+});
+
+describe("HostedDbWorkspaceStorage — data isolation", () => {
+  it("isolates plans between users", async () => {
+    const { db } = createDb(`file:${tempDbPath}`);
+    const userA = new HostedDbWorkspaceStorage("user-A", db);
+    const userB = new HostedDbWorkspaceStorage("user-B", db);
+    await userA.createWorkspace({ name: "A", id: "ws", makeCurrent: true });
+    await userB.createWorkspace({ name: "B", id: "ws", makeCurrent: true });
+    const ts = now();
+    await userA.createPlan(plan("p1", { createdAt: ts, updatedAt: ts }));
+    const plansA = await userA.listPlans();
+    const plansB = await userB.listPlans();
+    expect(plansA).toHaveLength(1);
+    expect(plansB).toHaveLength(0);
+  });
+});

--- a/packages/storage-db/tests/storage-db-sessions.test.ts
+++ b/packages/storage-db/tests/storage-db-sessions.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createDb } from "@quillby/database";
+import { HostedDbWorkspaceStorage } from "../src/index.js";
+
+let tempDir = "";
+let tempDbPath = "";
+
+function makeStorage(userId = "test-user"): HostedDbWorkspaceStorage {
+  const { db } = createDb(`file:${tempDbPath}`);
+  return new HostedDbWorkspaceStorage(userId, db);
+}
+
+async function withWorkspace(storage: HostedDbWorkspaceStorage): Promise<string> {
+  await storage.createWorkspace({ name: "Test", id: "test-ws", makeCurrent: true });
+  return "test-ws";
+}
+
+function makeSession(overrides: Partial<{
+  id: string; workspaceId: string; state: "planning" | "executing" | "reviewing" | "closing";
+}> = {}) {
+  const now = new Date().toISOString();
+  return {
+    id: overrides.id ?? "session-1",
+    workspaceId: overrides.workspaceId ?? "test-ws",
+    scope: { type: "freeform" as const, goal: "Test session", constraints: [] as string[] },
+    state: overrides.state ?? ("planning" as const),
+    degradation: { warnings: [] as string[] },
+    startedAt: now,
+    lastActivityAt: now,
+  };
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-db-sessions-"));
+  tempDbPath = path.join(tempDir, "test.db");
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("HostedDbWorkspaceStorage — SessionStore", () => {
+  describe("createSession", () => {
+    it("inserts a session with scope and degradation as JSON", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      await storage.createSession(makeSession());
+      const loaded = await storage.loadSession("session-1");
+      expect(loaded).not.toBeNull();
+      expect(loaded!.scope.goal).toBe("Test session");
+      expect(loaded!.degradation.warnings).toEqual([]);
+    });
+  });
+
+  describe("loadSession", () => {
+    it("returns null for missing session", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const result = await storage.loadSession("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("listSessions", () => {
+    it("returns sessions ordered by lastActivity desc", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      await storage.createSession(makeSession({ id: "s1" }));
+      await new Promise((r) => setTimeout(r, 10));
+      await storage.createSession(makeSession({ id: "s2" }));
+      const sessions = await storage.listSessions();
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0]!.id).toBe("s2");
+    });
+
+    it("returns empty when no sessions", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const sessions = await storage.listSessions();
+      expect(sessions).toHaveLength(0);
+    });
+  });
+
+  describe("updateSession", () => {
+    it("updates state", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      await storage.createSession(makeSession());
+      await storage.updateSession("session-1", { state: "executing" });
+      const loaded = await storage.loadSession("session-1");
+      expect(loaded!.state).toBe("executing");
+    });
+  });
+
+  describe("closeSession", () => {
+    it("sets state to closing and adds closedAt", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      await storage.createSession(makeSession());
+      await storage.closeSession("session-1");
+      const loaded = await storage.loadSession("session-1");
+      expect(loaded!.state).toBe("closing");
+      expect(loaded!.closedAt).toBeDefined();
+    });
+  });
+
+  describe("findStaleSessions", () => {
+    it("finds sessions older than threshold", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const stale = makeSession({ id: "stale", state: "executing" });
+      stale.lastActivityAt = new Date(Date.now() - 60_000).toISOString();
+      await storage.createSession(stale);
+      await storage.createSession(makeSession({ id: "recent" }));
+      const staleSessions = await storage.findStaleSessions(30_000);
+      expect(staleSessions).toHaveLength(1);
+      expect(staleSessions[0]!.id).toBe("stale");
+    });
+
+    it("excludes closed sessions", async () => {
+      const storage = makeStorage();
+      await withWorkspace(storage);
+      const closed = makeSession({ id: "closed", state: "closing" });
+      closed.lastActivityAt = new Date(Date.now() - 60_000).toISOString();
+      await storage.createSession(closed);
+      await storage.closeSession("closed");
+      const stale = await storage.findStaleSessions(1);
+      expect(stale).toHaveLength(0);
+    });
+  });
+});

--- a/packages/storage-db/tests/storage-db-workspace.test.ts
+++ b/packages/storage-db/tests/storage-db-workspace.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createDb } from "@quillby/database";
+import { HostedDbWorkspaceStorage } from "../src/index.js";
+
+let tempDir = "";
+let tempDbPath = "";
+
+function makeStorage(userId = "test-user"): HostedDbWorkspaceStorage {
+  const { db } = createDb(`file:${tempDbPath}`);
+  return new HostedDbWorkspaceStorage(userId, db);
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-db-ws-"));
+  tempDbPath = path.join(tempDir, "test.db");
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("HostedDbWorkspaceStorage — Workspace CRUD", () => {
+  describe("createWorkspace", () => {
+    it("creates and lists a workspace", async () => {
+      const storage = makeStorage();
+      const meta = await storage.createWorkspace({ name: "My Workspace", id: "my-ws", makeCurrent: true });
+      expect(meta.name).toBe("My Workspace");
+      const workspaces = await storage.listWorkspaces();
+      expect(workspaces.length).toBeGreaterThanOrEqual(1);
+      expect(workspaces.some((w) => w.id === "my-ws")).toBe(true);
+    });
+
+    it("throws on duplicate workspace id", async () => {
+      const storage = makeStorage();
+      await storage.createWorkspace({ name: "A", id: "ws", makeCurrent: true });
+      await expect(storage.createWorkspace({ name: "B", id: "ws" })).rejects.toThrow("already exists");
+    });
+
+    it("auto-creates default workspace on first use", async () => {
+      const storage = makeStorage("new-user");
+      const workspaces = await storage.listWorkspaces();
+      expect(workspaces.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("workspaceExists", () => {
+    it("returns true for existing workspace", async () => {
+      const storage = makeStorage();
+      await storage.createWorkspace({ name: "Test", id: "test-ws", makeCurrent: true });
+      expect(await storage.workspaceExists("test-ws")).toBe(true);
+    });
+
+    it("returns false for missing workspace", async () => {
+      const storage = makeStorage();
+      expect(await storage.workspaceExists("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("loadWorkspace", () => {
+    it("loads a created workspace", async () => {
+      const storage = makeStorage();
+      await storage.createWorkspace({ name: "Loaded", id: "load-ws", makeCurrent: true });
+      const loaded = await storage.loadWorkspace("load-ws");
+      expect(loaded).not.toBeNull();
+      expect(loaded!.name).toBe("Loaded");
+    });
+
+    it("returns null for missing workspace", async () => {
+      const storage = makeStorage();
+      expect(await storage.loadWorkspace("nonexistent")).toBeNull();
+    });
+  });
+
+  describe("updateWorkspaceMetadata", () => {
+    it("updates clone consent", async () => {
+      const wsStorage = makeStorage("user-upd");
+      await wsStorage.createWorkspace({ name: "WS", id: "ws", makeCurrent: true });
+      await wsStorage.updateWorkspaceMetadata({ cloneConsentGranted: true, cloneConsentAt: new Date().toISOString() });
+      const loaded = await wsStorage.loadWorkspace("ws");
+      expect(loaded!.cloneConsentGranted).toBe(true);
+    });
+  });
+
+  describe("getCurrentWorkspaceId / setCurrentWorkspace", () => {
+    it("returns the current workspace id", async () => {
+      const storage = makeStorage();
+      await storage.createWorkspace({ name: "A", id: "ws-a", makeCurrent: false });
+      await storage.createWorkspace({ name: "B", id: "ws-b", makeCurrent: true });
+      const id = await storage.getCurrentWorkspaceId();
+      expect(id).toBe("ws-b");
+    });
+
+    it("switches current workspace", async () => {
+      const storage = makeStorage();
+      await storage.createWorkspace({ name: "A", id: "ws-a", makeCurrent: true });
+      await storage.createWorkspace({ name: "B", id: "ws-b", makeCurrent: false });
+      await storage.setCurrentWorkspace("ws-b");
+      expect(await storage.getCurrentWorkspaceId()).toBe("ws-b");
+    });
+  });
+});
+
+// Jobs are tested via MCP server integration tests
+// (the hosted_workspace_job table has a FK to user(id) from Better Auth schema)
+
+describe("HostedDbWorkspaceStorage — Plan info", () => {
+  it("returns free plan by default", async () => {
+    const storage = makeStorage();
+    const plan = await storage.getPlan();
+    expect(plan).toBe("free");
+  });
+});

--- a/packages/storage-db/vitest.config.ts
+++ b/packages/storage-db/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    testTimeout: 15_000,
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      thresholds: {
+        statements: 40,
+        branches: 35,
+        functions: 50,
+        lines: 42,
+      },
+    },
+  },
+});

--- a/packages/storage-fs/package.json
+++ b/packages/storage-fs/package.json
@@ -14,7 +14,13 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "test:unit": "vitest run",
     "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
   },
   "dependencies": {
     "@quillby/config": "workspace:*",

--- a/packages/storage-fs/tests/campaigns.test.ts
+++ b/packages/storage-fs/tests/campaigns.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import os from "os";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-test-"));
+const campaignsDir = path.join(tmpDir, "campaigns");
+
+vi.mock("@quillby/workspace", () => ({
+  getCurrentWorkspaceId: () => "test-ws",
+  getWorkspacePaths: () => ({
+    campaignsDir,
+  }),
+}));
+
+beforeEach(() => {
+  fs.mkdirSync(campaignsDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+import {
+  createCampaign,
+  loadCampaign,
+  listCampaigns,
+  updateCampaign,
+  deleteCampaign,
+  saveBlueprint,
+  loadBlueprint,
+  listBlueprints,
+  deleteBlueprint,
+} from "../src/campaigns.js";
+
+const now = new Date().toISOString();
+
+const sampleCampaign = {
+  id: "camp-1",
+  workspaceId: "test-ws",
+  name: "Test Campaign",
+  status: "planning" as const,
+  blueprintId: "",
+  stages: [{ name: "Research", tool: "research_agent", params: {}, dependsOn: [], retryCount: 0 }],
+  executions: [],
+  createdAt: now,
+  updatedAt: now,
+};
+
+const sampleBlueprint = {
+  id: "bp-1",
+  name: "Test Blueprint",
+  description: "",
+  tags: [],
+  stages: [{ name: "Research", tool: "research_agent", params: {}, dependsOn: [], retryCount: 0 }],
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("campaigns CRUD", () => {
+  it("creates and loads a campaign", () => {
+    createCampaign(sampleCampaign);
+    const loaded = loadCampaign("camp-1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.name).toBe("Test Campaign");
+  });
+
+  it("returns null for missing campaign", () => {
+    expect(loadCampaign("nonexistent")).toBeNull();
+  });
+
+  it("lists campaigns", () => {
+    createCampaign(sampleCampaign);
+    createCampaign({ ...sampleCampaign, id: "camp-2", name: "Second" });
+    const all = listCampaigns();
+    expect(all).toHaveLength(2);
+  });
+
+  it("filters campaigns by status", () => {
+    createCampaign(sampleCampaign);
+    createCampaign({ ...sampleCampaign, id: "camp-2", status: "active" });
+    const active = listCampaigns("active");
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe("camp-2");
+  });
+
+  it("updates a campaign", () => {
+    createCampaign(sampleCampaign);
+    updateCampaign("camp-1", { name: "Updated" });
+    const loaded = loadCampaign("camp-1");
+    expect(loaded!.name).toBe("Updated");
+    expect(loaded!.updatedAt).not.toBe(now);
+  });
+
+  it("throws on updating missing campaign", () => {
+    expect(() => updateCampaign("nonexistent", { name: "x" })).toThrow();
+  });
+
+  it("deletes a campaign", () => {
+    createCampaign(sampleCampaign);
+    deleteCampaign("camp-1");
+    expect(loadCampaign("camp-1")).toBeNull();
+  });
+});
+
+describe("blueprints CRUD", () => {
+  it("saves and loads a blueprint", () => {
+    saveBlueprint(sampleBlueprint);
+    const loaded = loadBlueprint("bp-1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.name).toBe("Test Blueprint");
+  });
+
+  it("returns null for missing blueprint", () => {
+    expect(loadBlueprint("nonexistent")).toBeNull();
+  });
+
+  it("lists blueprints", () => {
+    saveBlueprint(sampleBlueprint);
+    saveBlueprint({ ...sampleBlueprint, id: "bp-2", name: "Second" });
+    expect(listBlueprints()).toHaveLength(2);
+  });
+
+  it("deletes a blueprint", () => {
+    saveBlueprint(sampleBlueprint);
+    deleteBlueprint("bp-1");
+    expect(loadBlueprint("bp-1")).toBeNull();
+  });
+});

--- a/packages/storage-fs/tests/jobs.test.ts
+++ b/packages/storage-fs/tests/jobs.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import os from "os";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-test-"));
+const root = tmpDir;
+
+vi.mock("@quillby/workspace", () => ({
+  getCurrentWorkspaceId: () => "test-ws",
+  getWorkspacePaths: () => ({
+    root,
+  }),
+}));
+
+beforeEach(() => {
+  fs.mkdirSync(root, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+import { saveJob, loadJob, listJobs, updateJob } from "../src/jobs.js";
+
+const now = new Date().toISOString();
+
+const sampleJob = {
+  id: "job-1",
+  workspaceId: "test-ws",
+  modality: "image" as const,
+  prompt: "A cat",
+  status: "queued" as const,
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("jobs CRUD", () => {
+  it("saves and loads a job", () => {
+    saveJob(sampleJob);
+    const loaded = loadJob("job-1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.prompt).toBe("A cat");
+  });
+
+  it("returns null for missing job", () => {
+    expect(loadJob("nonexistent")).toBeNull();
+  });
+
+  it("lists all jobs", () => {
+    saveJob(sampleJob);
+    saveJob({ ...sampleJob, id: "job-2", modality: "audio" });
+    expect(listJobs()).toHaveLength(2);
+  });
+
+  it("filters jobs by modality", () => {
+    saveJob(sampleJob);
+    saveJob({ ...sampleJob, id: "job-2", modality: "audio" });
+    const imageJobs = listJobs("image");
+    expect(imageJobs).toHaveLength(1);
+    expect(imageJobs[0].id).toBe("job-1");
+  });
+
+  it("updates a job", () => {
+    saveJob(sampleJob);
+    updateJob("job-1", { status: "done" });
+    const loaded = loadJob("job-1");
+    expect(loaded!.status).toBe("done");
+  });
+
+  it("does not throw on updating missing job", () => {
+    expect(() => updateJob("nonexistent", { status: "done" })).not.toThrow();
+  });
+
+  it("prepends new jobs", () => {
+    saveJob(sampleJob);
+    saveJob({ ...sampleJob, id: "job-2" });
+    const all = listJobs();
+    expect(all[0].id).toBe("job-2");
+  });
+});

--- a/packages/storage-fs/tests/plans.test.ts
+++ b/packages/storage-fs/tests/plans.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import os from "os";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-test-"));
+const plansDir = path.join(tmpDir, "plans");
+
+vi.mock("@quillby/workspace", () => ({
+  getCurrentWorkspaceId: () => "test-ws",
+  getWorkspacePaths: () => ({
+    plansDir,
+  }),
+}));
+
+beforeEach(() => {
+  fs.mkdirSync(plansDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+import {
+  createPlan,
+  loadPlan,
+  listPlans,
+  updatePlan,
+  deletePlan,
+  createTask,
+  loadTask,
+  listTasks,
+  updateTask,
+  deleteTask,
+  getTodayQueue,
+  getCalendar,
+} from "../src/plans.js";
+
+const now = new Date().toISOString();
+
+const samplePlan = {
+  id: "plan-1",
+  name: "Test Plan",
+  status: "active" as const,
+  description: "",
+  tags: [],
+  createdAt: now,
+  updatedAt: now,
+};
+
+const sampleTask = {
+  id: "task-1",
+  planId: "plan-1",
+  title: "Write post",
+  type: "compose" as const,
+  priority: "p1" as const,
+  status: "todo" as const,
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("plans CRUD", () => {
+  it("creates and loads a plan", () => {
+    createPlan(samplePlan);
+    const loaded = loadPlan("plan-1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.name).toBe("Test Plan");
+  });
+
+  it("returns null for missing plan", () => {
+    expect(loadPlan("nonexistent")).toBeNull();
+  });
+
+  it("lists plans", () => {
+    createPlan(samplePlan);
+    createPlan({ ...samplePlan, id: "plan-2", name: "Second" });
+    expect(listPlans()).toHaveLength(2);
+  });
+
+  it("filters plans by status", () => {
+    createPlan(samplePlan);
+    createPlan({ ...samplePlan, id: "plan-2", status: "archived" });
+    const active = listPlans("active");
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe("plan-1");
+  });
+
+  it("updates a plan", () => {
+    createPlan(samplePlan);
+    updatePlan("plan-1", { name: "Updated" });
+    expect(loadPlan("plan-1")!.name).toBe("Updated");
+  });
+
+  it("throws on updating missing plan", () => {
+    expect(() => updatePlan("nonexistent", { name: "x" })).toThrow();
+  });
+
+  it("deletes a plan and its tasks", () => {
+    createPlan(samplePlan);
+    createTask(sampleTask);
+    deletePlan("plan-1");
+    expect(loadPlan("plan-1")).toBeNull();
+    expect(listTasks("plan-1")).toEqual([]);
+  });
+});
+
+describe("tasks CRUD", () => {
+  it("creates and loads a task", () => {
+    createPlan(samplePlan);
+    createTask(sampleTask);
+    const loaded = loadTask("task-1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.title).toBe("Write post");
+  });
+
+  it("returns null for missing task", () => {
+    expect(loadTask("nonexistent")).toBeNull();
+  });
+
+  it("lists tasks for a plan", () => {
+    createPlan(samplePlan);
+    createTask(sampleTask);
+    createTask({ ...sampleTask, id: "task-2", title: "Review" });
+    expect(listTasks("plan-1")).toHaveLength(2);
+  });
+
+  it("replaces existing task on duplicate id", () => {
+    createPlan(samplePlan);
+    createTask(sampleTask);
+    createTask({ ...sampleTask, title: "Updated" });
+    const tasks = listTasks("plan-1");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].title).toBe("Updated");
+  });
+
+  it("updates a task", () => {
+    createPlan(samplePlan);
+    createTask(sampleTask);
+    updateTask("task-1", { status: "doing" });
+    const loaded = loadTask("task-1");
+    expect(loaded!.status).toBe("doing");
+  });
+
+  it("deletes a task", () => {
+    createPlan(samplePlan);
+    createTask(sampleTask);
+    deleteTask("task-1");
+    expect(loadTask("task-1")).toBeNull();
+  });
+});
+
+describe("getTodayQueue", () => {
+  it("returns tasks that are todo or doing with no due date", () => {
+    createPlan(samplePlan);
+    createTask({ ...sampleTask, id: "t-todo", status: "todo" });
+    createTask({ ...sampleTask, id: "t-doing", status: "doing" });
+    const queue = getTodayQueue();
+    expect(queue).toHaveLength(2);
+  });
+
+  it("excludes done and cancelled tasks", () => {
+    createPlan(samplePlan);
+    createTask({ ...sampleTask, id: "t-done", status: "done" });
+    createTask({ ...sampleTask, id: "t-cancelled", status: "cancelled" });
+    expect(getTodayQueue()).toHaveLength(0);
+  });
+
+  it("includes overdue tasks", () => {
+    createPlan(samplePlan);
+    createTask({ ...sampleTask, id: "t-overdue", status: "todo", dueDate: "2020-01-01" });
+    expect(getTodayQueue()).toHaveLength(1);
+  });
+
+  it("excludes future tasks", () => {
+    createPlan(samplePlan);
+    createTask({ ...sampleTask, id: "t-future", status: "todo", dueDate: "2099-12-31" });
+    expect(getTodayQueue()).toHaveLength(0);
+  });
+});
+
+describe("getCalendar", () => {
+  it("groups tasks by date within range", () => {
+    createPlan(samplePlan);
+    createTask({ ...sampleTask, id: "t-1", dueDate: "2026-06-15" });
+    createTask({ ...sampleTask, id: "t-2", dueDate: "2026-06-15" });
+    createTask({ ...sampleTask, id: "t-3", dueDate: "2026-06-16" });
+    const entries = getCalendar("2026-06-15", "2026-06-20");
+    expect(entries).toHaveLength(2);
+    expect(entries.find((e) => e.date === "2026-06-15")!.tasks).toHaveLength(2);
+  });
+
+  it("excludes tasks outside date range", () => {
+    createPlan(samplePlan);
+    createTask({ ...sampleTask, id: "t-out", dueDate: "2026-07-01" });
+    expect(getCalendar("2026-06-01", "2026-06-30")).toHaveLength(0);
+  });
+});

--- a/packages/storage-fs/tests/sessions.test.ts
+++ b/packages/storage-fs/tests/sessions.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import os from "os";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-test-"));
+const sessionsDir = path.join(tmpDir, "sessions");
+
+vi.mock("@quillby/workspace", () => ({
+  getCurrentWorkspaceId: () => "test-ws",
+  getWorkspacePaths: () => ({
+    sessionsDir,
+  }),
+}));
+
+beforeEach(() => {
+  fs.mkdirSync(sessionsDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+import {
+  createSession,
+  loadSession,
+  listSessions,
+  updateSession,
+  closeSession,
+  findStaleSessions,
+} from "../src/sessions.js";
+
+const now = new Date().toISOString();
+
+const sampleSession = {
+  id: "sess-1",
+  workspaceId: "test-ws",
+  scope: { type: "freeform" as const, goal: "Test session", constraints: [] },
+  state: "planning" as const,
+  degradation: { warnings: [] },
+  startedAt: now,
+  lastActivityAt: now,
+};
+
+describe("sessions CRUD", () => {
+  it("creates and loads a session", () => {
+    createSession(sampleSession);
+    const loaded = loadSession("sess-1");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.state).toBe("planning");
+  });
+
+  it("returns null for missing session", () => {
+    expect(loadSession("nonexistent")).toBeNull();
+  });
+
+  it("lists sessions", () => {
+    createSession(sampleSession);
+    createSession({ ...sampleSession, id: "sess-2" });
+    expect(listSessions()).toHaveLength(2);
+  });
+
+  it("updates a session", () => {
+    createSession(sampleSession);
+    updateSession("sess-1", { state: "executing" });
+    const loaded = loadSession("sess-1");
+    expect(loaded!.state).toBe("executing");
+  });
+
+  it("throws on updating missing session", () => {
+    expect(() => updateSession("nonexistent", { state: "executing" })).toThrow();
+  });
+
+  it("closes a session", () => {
+    createSession(sampleSession);
+    closeSession("sess-1");
+    const loaded = loadSession("sess-1");
+    expect(loaded!.state).toBe("closing");
+    expect(loaded!.closedAt).toBeDefined();
+  });
+
+  it("throws on closing missing session", () => {
+    expect(() => closeSession("nonexistent")).toThrow();
+  });
+
+  it("finds stale sessions", () => {
+    const oldTime = new Date(Date.now() - 60_000).toISOString();
+    createSession({ ...sampleSession, id: "sess-old", lastActivityAt: oldTime });
+    createSession({ ...sampleSession, id: "sess-fresh" });
+    const stale = findStaleSessions(30_000);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("sess-old");
+  });
+
+  it("does not return closed sessions as stale", () => {
+    const oldTime = new Date(Date.now() - 60_000).toISOString();
+    createSession({
+      ...sampleSession,
+      id: "sess-closed",
+      state: "closing",
+      closedAt: oldTime,
+      lastActivityAt: oldTime,
+    });
+    const stale = findStaleSessions(30_000);
+    expect(stale.find((s) => s.id === "sess-closed")).toBeUndefined();
+  });
+});

--- a/packages/storage-fs/tests/structures.test.ts
+++ b/packages/storage-fs/tests/structures.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import os from "os";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-test-"));
+const outputDir = path.join(tmpDir, "output");
+const cacheDir = path.join(tmpDir, "cache");
+const latestHarvestPointer = path.join(tmpDir, "latest-harvest.txt");
+
+vi.mock("@quillby/workspace", () => ({
+  getCurrentWorkspaceId: () => "test-ws",
+  getWorkspacePaths: () => ({
+    outputDir,
+    cacheDir,
+    latestHarvestPointer,
+  }),
+}));
+
+beforeEach(() => {
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.mkdirSync(cacheDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+import {
+  latestHarvestExists,
+  loadLatestHarvest,
+  saveDraft,
+  listLocalDrafts,
+  saveCurationState,
+} from "../src/structures.js";
+
+describe("latestHarvestExists", () => {
+  it("returns false when no pointer file", () => {
+    expect(latestHarvestExists()).toBe(false);
+  });
+
+  it("returns false when pointer points to missing file", () => {
+    fs.writeFileSync(latestHarvestPointer, "/nonexistent/path.json");
+    expect(latestHarvestExists()).toBe(false);
+  });
+
+  it("returns true when pointer points to existing file", () => {
+    const bundlePath = path.join(outputDir, "structures.json");
+    fs.writeFileSync(bundlePath, JSON.stringify({ generatedAt: new Date().toISOString(), dateLabel: "Test", cards: [] }));
+    fs.writeFileSync(latestHarvestPointer, bundlePath);
+    expect(latestHarvestExists()).toBe(true);
+  });
+});
+
+describe("loadLatestHarvest", () => {
+  it("throws when no harvest exists", () => {
+    expect(() => loadLatestHarvest()).toThrow("No harvest found");
+  });
+
+  it("throws when pointer is invalid", () => {
+    fs.writeFileSync(latestHarvestPointer, "");
+    expect(() => loadLatestHarvest()).toThrow("invalid");
+  });
+
+  it("loads a valid harvest bundle", () => {
+    const bundlePath = path.join(outputDir, "structures.json");
+    const bundle = {
+      generatedAt: new Date().toISOString(),
+      dateLabel: "Jun 1, 2026",
+      cards: [{ id: 1, title: "Test", source: "X", link: "https://x.com", thesis: "T", relevanceScore: 5, relevanceReason: "R", keyInsights: [], insightOptions: [], takeOptions: [], angleOptions: [], hookOptions: [], wireframeOptions: [], trendTags: [], references: [] }],
+    };
+    fs.writeFileSync(bundlePath, JSON.stringify(bundle));
+    fs.writeFileSync(latestHarvestPointer, bundlePath);
+    const loaded = loadLatestHarvest();
+    expect(loaded.cards).toHaveLength(1);
+    expect(loaded.cards[0].title).toBe("Test");
+  });
+});
+
+describe("saveDraft", () => {
+  it("saves a draft to the output dir", () => {
+    const filePath = saveDraft("Post content", "linkedin");
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("Post content\n");
+  });
+
+  it("saves a draft with card ID in filename", () => {
+    const filePath = saveDraft("Content", "x", 42);
+    expect(filePath).toContain("_card42.md");
+  });
+
+  it("saves to harvest output dir when pointer exists", () => {
+    const harvestDir = path.join(outputDir, "2026-06-01");
+    const bundlePath = path.join(harvestDir, "structures.json");
+    fs.mkdirSync(harvestDir, { recursive: true });
+    fs.writeFileSync(bundlePath, JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      dateLabel: "Test",
+      cards: [],
+    }));
+    fs.writeFileSync(latestHarvestPointer, bundlePath);
+    const filePath = saveDraft("Draft", "blog");
+    expect(filePath).toContain(harvestDir);
+  });
+});
+
+describe("listLocalDrafts", () => {
+  it("returns empty when no drafts exist", () => {
+    expect(listLocalDrafts()).toEqual([]);
+  });
+
+  it("lists drafts from output dir", () => {
+    fs.writeFileSync(path.join(outputDir, "linkedin.md"), "Post text\n");
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].platform).toBe("linkedin");
+  });
+
+  it("ignores structures.md", () => {
+    fs.writeFileSync(path.join(outputDir, "structures.md"), "# Harvest");
+    const drafts = listLocalDrafts();
+    expect(drafts).toHaveLength(0);
+  });
+
+  it("extracts card ID from filename", () => {
+    fs.writeFileSync(path.join(outputDir, "x_card5.md"), "Content\n");
+    const drafts = listLocalDrafts();
+    expect(drafts[0].cardId).toBe(5);
+  });
+
+  it("provides preview from first 200 chars", () => {
+    const long = "A".repeat(300);
+    fs.writeFileSync(path.join(outputDir, "linkedin.md"), long);
+    const drafts = listLocalDrafts();
+    expect(drafts[0].preview.length).toBeLessThanOrEqual(200);
+  });
+
+  it("deduplicates drafts across dirs", () => {
+    const draftPath = path.join(outputDir, "linkedin.md");
+    fs.writeFileSync(draftPath, "Content\n");
+    const harvestDir = path.join(outputDir, "harvest-1");
+    fs.mkdirSync(harvestDir, { recursive: true });
+    const harvestDraftPath = path.join(harvestDir, "linkedin.md");
+    fs.writeFileSync(harvestDraftPath, "Content\n");
+    const bundlePath = path.join(harvestDir, "structures.json");
+    fs.writeFileSync(bundlePath, JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      dateLabel: "Test",
+      cards: [],
+    }));
+    fs.writeFileSync(latestHarvestPointer, bundlePath);
+    const drafts = listLocalDrafts();
+    const uniquePaths = new Set(drafts.map((d) => d.id));
+    expect(uniquePaths.size).toBe(drafts.length);
+  });
+
+  it("sorts drafts by creation date descending", () => {
+    fs.writeFileSync(path.join(outputDir, "old.md"), "Old\n");
+    const oldStat = fs.statSync(path.join(outputDir, "old.md"));
+    const oldTime = oldStat.mtime.getTime() - 1000;
+    fs.utimesSync(path.join(outputDir, "old.md"), oldTime / 1000, oldTime / 1000);
+
+    fs.writeFileSync(path.join(outputDir, "new.md"), "New\n");
+    const drafts = listLocalDrafts();
+    expect(drafts[0].platform).toBe("new");
+  });
+});
+
+describe("saveCurationState", () => {
+  it("throws when no harvest exists", () => {
+    expect(() => saveCurationState({ "1": "shortlisted" })).toThrow("No harvest found");
+  });
+
+  it("merges curation state into existing harvest", () => {
+    const bundlePath = path.join(outputDir, "structures.json");
+    fs.writeFileSync(bundlePath, JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      dateLabel: "Test",
+      cards: [{ id: 1, title: "T", source: "S", link: "https://x.com", thesis: "X", relevanceScore: 5, relevanceReason: "R", keyInsights: [], insightOptions: [], takeOptions: [], angleOptions: [], hookOptions: [], wireframeOptions: [], trendTags: [], references: [] }],
+      curationState: { "1": "shortlisted" },
+    }));
+    fs.writeFileSync(latestHarvestPointer, bundlePath);
+    saveCurationState({ "1": "skipped", "2": "shortlisted" });
+    const raw = JSON.parse(fs.readFileSync(bundlePath, "utf-8"));
+    expect(raw.curationState["1"]).toBe("skipped");
+    expect(raw.curationState["2"]).toBe("shortlisted");
+  });
+});

--- a/packages/storage-fs/vitest.config.ts
+++ b/packages/storage-fs/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: {
+        statements: 80,
+        branches: 65,
+        functions: 70,
+        lines: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,13 @@ importers:
       zod:
         specifier: ^3.24.0
         version: 3.25.76
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.7(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -329,6 +336,13 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.1)(kysely@0.28.15)
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.7(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/storage-fs:
     dependencies:
@@ -344,6 +358,13 @@ importers:
       '@quillby/workspace':
         specifier: workspace:*
         version: link:../workspace
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.7(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/workspace:
     dependencies:


### PR DESCRIPTION
## Summary

Adds unit test infrastructure and tests for 3 packages previously lacking coverage. Fixes one bug discovered during testing.

## Changes

### packages/content (51 tests)
- Plan types: task type/priority/status schemas, plan schema with defaults, calendar entries
- Campaign types + pipeline: all 6 pipeline functions (transitionStage, areDependenciesMet, getNextStages, checkAllCompleted, canRetryStage, initialExecutionLogs)
- Session types: scope, state, degradation, full session schema
- **Bug fix:** `transitionStage` only checked completed executions instead of verifying all stages are done

### packages/storage-fs (64 tests)
- Campaign CRUD: create/load/list/update/delete + blueprint operations
- Jobs CRUD: save/load/list/update with modality filtering
- Sessions CRUD: create/load/list/update/close + stale detection
- Plans CRUD: create/load/list/update/delete + getTodayQueue + getCalendar filtering
- Structures: harvest pointer detection, draft saving, curation state merging, draft listing with dedup

### packages/storage-db (34 tests)
- PlanStorage: create/load/list/update/delete plans + tasks, getTodayQueue, getCalendar, data isolation
- SessionStore: create/load/list/update/close + stale detection
- Workspace CRUD: create/list/load/exists/setCurrent + clone consent updates

## Test Infrastructure
- Vitest configs with coverage thresholds for all 3 packages
- ESM-style imports with .js extensions (matching codebase convention)
- Temp directory patterns for filesystem tests
- File-based libSQL for DB-backed tests (matches existing MCP server test pattern)

## Coverage Results
| Package | Statements | Functions | Lines |
|---------|-----------|-----------|-------|
| core | 92% | 50% | 96% |
| content | 98% | 100% | 100% |
| storage-fs | 81% | 89% | 81% |
| storage-db | 42% | 53% | 45% |

storage-db coverage is lower due to its 1319-line monolithic structure; deep coverage comes from MCP server integration tests (41 test files).

Closes T-000557, T-000559, T-000563