### PR TITLE
test(campaign): add comprehensive test suite for campaign system

### DIFF
--- a/apps/mcp-server/tests/unit/campaign-pipeline.test.ts
+++ b/apps/mcp-server/tests/unit/campaign-pipeline.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it } from "vitest";
+import {
+  transitionStage,
+  areDependenciesMet,
+  getNextStages,
+  checkAllCompleted,
+  canRetryStage,
+  initialExecutionLogs,
+  type Campaign,
+  type StageConfig,
+} from "@quillby/content";
+
+function makeCampaign(overrides: Partial<Campaign> = {}): Campaign {
+  return {
+    id: "camp-test",
+    workspaceId: "default",
+    blueprintId: "bp-1",
+    name: "Test Campaign",
+    status: "active",
+    stages: [
+      { name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 0 },
+      { name: "write", tool: "composer", params: {}, dependsOn: ["research"], retryCount: 2 },
+      { name: "review", tool: "editor", params: {}, dependsOn: ["write"], retryCount: 0 },
+      { name: "publish", tool: "deploy", params: {}, dependsOn: ["review"], retryCount: 0 },
+    ],
+    executions: [
+      { stageName: "research", status: "completed", retryAttempt: 0, completedAt: new Date().toISOString() },
+      { stageName: "write", status: "pending", retryAttempt: 0 },
+      { stageName: "review", status: "pending", retryAttempt: 0 },
+      { stageName: "publish", status: "pending", retryAttempt: 0 },
+    ],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function nowApprox(a: string, b: string): boolean {
+  return Math.abs(new Date(a).getTime() - new Date(b).getTime()) < 1000;
+}
+
+describe("transitionStage", () => {
+  it("transitions a stage to running", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "write", "running");
+    const exec = updated.executions.find((e) => e.stageName === "write")!;
+    expect(exec.status).toBe("running");
+    expect(exec.startedAt).toBeDefined();
+    expect(updated.status).toBe("active");
+  });
+
+  it("transitions a stage to completed", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "write", "completed", { result: { wordCount: 500 } });
+    const exec = updated.executions.find((e) => e.stageName === "write")!;
+    expect(exec.status).toBe("completed");
+    expect(exec.completedAt).toBeDefined();
+    expect(exec.result).toEqual({ wordCount: 500 });
+  });
+
+  it("transitions campaign to completed when all stages done", () => {
+    const campaign = makeCampaign();
+    let updated = transitionStage(campaign, "write", "completed");
+    updated = transitionStage(updated, "review", "completed");
+    updated = transitionStage(updated, "publish", "completed");
+    expect(updated.status).toBe("completed");
+    expect(updated.completedAt).toBeDefined();
+  });
+
+  it("sets campaign status to failed when any stage fails", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "write", "failed", { error: "Out of ideas" });
+    expect(updated.status).toBe("failed");
+    expect(updated.error).toBe("Out of ideas");
+  });
+
+  it("sets startedAt when first stage transitions to running", () => {
+    const campaign = makeCampaign({ startedAt: undefined });
+    const updated = transitionStage(campaign, "write", "running");
+    expect(updated.startedAt).toBeDefined();
+  });
+
+  it("preserves startedAt on subsequent transitions", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "write", "running");
+    expect(updated.startedAt).toBe(campaign.startedAt);
+  });
+
+  it("updates updatedAt on every transition", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "write", "running");
+    expect(nowApprox(updated.updatedAt, new Date().toISOString())).toBe(true);
+  });
+
+  it("replaces existing execution for the same stage", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "research", "completed", { result: { depth: "full" } });
+    expect(updated.executions.filter((e) => e.stageName === "research")).toHaveLength(1);
+    expect(updated.executions.find((e) => e.stageName === "research")!.result).toEqual({ depth: "full" });
+  });
+});
+
+describe("areDependenciesMet", () => {
+  it("returns true when no dependencies", () => {
+    const campaign = makeCampaign();
+    const stage: StageConfig = { name: "standalone", tool: "x", params: {}, dependsOn: [], retryCount: 0 };
+    expect(areDependenciesMet(stage, campaign)).toBe(true);
+  });
+
+  it("returns true when all deps completed", () => {
+    const campaign = makeCampaign();
+    const stage = campaign.stages[1]!;
+    expect(areDependenciesMet(stage, campaign)).toBe(true);
+  });
+
+  it("returns true when deps are skipped", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "skipped", retryAttempt: 0 },
+        { stageName: "write", status: "pending", retryAttempt: 0 },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    const stage = campaign.stages[1]!;
+    expect(areDependenciesMet(stage, campaign)).toBe(true);
+  });
+
+  it("returns false when a dep is still pending", () => {
+    const campaign = makeCampaign();
+    const stage = campaign.stages[3]!; // publish depends on review
+    expect(areDependenciesMet(stage, campaign)).toBe(false);
+  });
+
+  it("returns false when a dep has failed", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "failed", retryAttempt: 1, error: "Error" },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    const stage = campaign.stages[2]!; // review depends on write
+    expect(areDependenciesMet(stage, campaign)).toBe(false);
+  });
+
+  it("returns false when a dep execution is missing", () => {
+    const campaign = makeCampaign({ executions: [] });
+    const stage: StageConfig = { name: "x", tool: "t", params: {}, dependsOn: ["research"], retryCount: 0 };
+    expect(areDependenciesMet(stage, campaign)).toBe(false);
+  });
+});
+
+describe("getNextStages", () => {
+  it("returns stages whose deps are met and not started", () => {
+    const campaign = makeCampaign();
+    const next = getNextStages(campaign);
+    expect(next).toHaveLength(1);
+    expect(next[0]!.name).toBe("write");
+  });
+
+  it("returns multiple ready stages when deps are met", () => {
+    const campaign = makeCampaign({
+      stages: [
+        { name: "a", tool: "t1", params: {}, dependsOn: [], retryCount: 0 },
+        { name: "b", tool: "t2", params: {}, dependsOn: [], retryCount: 0 },
+      ],
+      executions: [],
+    });
+    const next = getNextStages(campaign);
+    expect(next).toHaveLength(2);
+  });
+
+  it("does not return already running stages", () => {
+    const campaign = makeCampaign({
+      stages: [
+        { name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 0 },
+        { name: "write", tool: "composer", params: {}, dependsOn: ["research"], retryCount: 2 },
+        { name: "publish", tool: "deploy", params: {}, dependsOn: ["research"], retryCount: 0 },
+      ],
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "running", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    const next = getNextStages(campaign);
+    expect(next.find((s) => s.name === "write")).toBeUndefined();
+    expect(next.find((s) => s.name === "publish")).toBeDefined();
+  });
+
+  it("does not return failed stages", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "failed", retryAttempt: 1, error: "Error" },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    const next = getNextStages(campaign);
+    expect(next.find((s) => s.name === "write")).toBeUndefined();
+    expect(next.find((s) => s.name === "review")).toBeUndefined(); // review depends on write
+  });
+
+  it("returns empty when all stages are done", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "completed", retryAttempt: 0 },
+        { stageName: "review", status: "completed", retryAttempt: 0 },
+        { stageName: "publish", status: "completed", retryAttempt: 0 },
+      ],
+    });
+    expect(getNextStages(campaign)).toHaveLength(0);
+  });
+});
+
+describe("checkAllCompleted", () => {
+  it("returns true when all stages completed", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "completed", retryAttempt: 0 },
+        { stageName: "review", status: "completed", retryAttempt: 0 },
+        { stageName: "publish", status: "completed", retryAttempt: 0 },
+      ],
+    });
+    expect(checkAllCompleted(campaign)).toBe(true);
+  });
+
+  it("returns true when some stages are skipped", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "skipped", retryAttempt: 0 },
+        { stageName: "write", status: "completed", retryAttempt: 0 },
+        { stageName: "review", status: "completed", retryAttempt: 0 },
+        { stageName: "publish", status: "skipped", retryAttempt: 0 },
+      ],
+    });
+    expect(checkAllCompleted(campaign)).toBe(true);
+  });
+
+  it("returns false when a stage is pending", () => {
+    const campaign = makeCampaign();
+    expect(checkAllCompleted(campaign)).toBe(false);
+  });
+
+  it("returns false when a stage has failed", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "failed", retryAttempt: 1 },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    expect(checkAllCompleted(campaign)).toBe(false);
+  });
+});
+
+describe("canRetryStage", () => {
+  it("returns true when retries remain", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "failed", retryAttempt: 0, error: "Error" },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    expect(canRetryStage(campaign, "write")).toBe(true);
+  });
+
+  it("returns false when retries exhausted", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "failed", retryAttempt: 2, error: "Error" },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    expect(canRetryStage(campaign, "write")).toBe(false);
+  });
+
+  it("returns false when stage is not failed", () => {
+    const campaign = makeCampaign();
+    expect(canRetryStage(campaign, "write")).toBe(false);
+  });
+
+  it("returns false when stage does not exist", () => {
+    const campaign = makeCampaign();
+    expect(canRetryStage(campaign, "nonexistent")).toBe(false);
+  });
+
+  it("returns false when execution does not exist", () => {
+    const campaign = makeCampaign({ executions: [] });
+    expect(canRetryStage(campaign, "research")).toBe(false);
+  });
+
+  it("returns false when stage has no retryCount (default 0)", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "failed", retryAttempt: 0, error: "E" },
+        { stageName: "write", status: "pending", retryAttempt: 0 },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    expect(canRetryStage(campaign, "research")).toBe(false);
+  });
+});
+
+describe("initialExecutionLogs", () => {
+  it("creates pending logs for each stage", () => {
+    const stages: StageConfig[] = [
+      { name: "a", tool: "t1", params: {}, dependsOn: [], retryCount: 0 },
+      { name: "b", tool: "t2", params: {}, dependsOn: [], retryCount: 0 },
+    ];
+    const logs = initialExecutionLogs(stages);
+    expect(logs).toHaveLength(2);
+    expect(logs[0]!.status).toBe("pending");
+    expect(logs[0]!.retryAttempt).toBe(0);
+    expect(logs[1]!.status).toBe("pending");
+  });
+});
+
+describe("edge cases", () => {
+  it("circular dependencies: getNextStages returns none when all depend on each other", () => {
+    const campaign = makeCampaign({
+      stages: [
+        { name: "a", tool: "t1", params: {}, dependsOn: ["b"], retryCount: 0 },
+        { name: "b", tool: "t2", params: {}, dependsOn: ["a"], retryCount: 0 },
+      ],
+      executions: [],
+    });
+    const next = getNextStages(campaign);
+    expect(next).toHaveLength(0);
+  });
+
+  it("last stage skipped marks campaign as completed", () => {
+    const campaign = makeCampaign({
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "skipped", retryAttempt: 0 },
+        { stageName: "review", status: "completed", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    expect(checkAllCompleted(campaign)).toBe(false);
+    const updated = transitionStage(campaign, "publish", "skipped");
+    expect(updated.status).toBe("completed");
+  });
+
+  it("retry exhaustion triggers no more retries", () => {
+    const campaign = makeCampaign({
+      stages: [
+        { name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 2 },
+        { name: "write", tool: "composer", params: {}, dependsOn: ["research"], retryCount: 2 },
+        { name: "review", tool: "editor", params: {}, dependsOn: ["write"], retryCount: 2 },
+        { name: "publish", tool: "deploy", params: {}, dependsOn: ["review"], retryCount: 2 },
+      ],
+      executions: [
+        { stageName: "research", status: "completed", retryAttempt: 0 },
+        { stageName: "write", status: "failed", retryAttempt: 2, error: "Final error" },
+        { stageName: "review", status: "pending", retryAttempt: 0 },
+        { stageName: "publish", status: "pending", retryAttempt: 0 },
+      ],
+    });
+    expect(canRetryStage(campaign, "write")).toBe(false);
+  });
+
+  it("all stage config fields survive transition", () => {
+    const campaign = makeCampaign({
+      stages: [
+        {
+          name: "research", tool: "gather",
+          params: { depth: "full" }, dependsOn: [], retryCount: 2, timeout: 30000, condition: "always",
+        },
+      ],
+    });
+    const updated = transitionStage(campaign, "research", "completed");
+    const stage = updated.stages.find((s) => s.name === "research")!;
+    expect(stage.timeout).toBe(30000);
+    expect(stage.condition).toBe("always");
+    expect(stage.retryCount).toBe(2);
+    expect(stage.params).toEqual({ depth: "full" });
+  });
+
+  it("transitionStage handles nonexistent stageName by creating phantom execution", () => {
+    const campaign = makeCampaign();
+    const updated = transitionStage(campaign, "nonexistent", "completed");
+    const exec = updated.executions.find((e) => e.stageName === "nonexistent")!;
+    expect(exec).toBeDefined();
+    expect(exec.status).toBe("completed");
+  });
+});

--- a/apps/mcp-server/tests/unit/campaign-schemas.test.ts
+++ b/apps/mcp-server/tests/unit/campaign-schemas.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import {
+  CampaignSchema,
+  BlueprintSchema,
+  StageConfigSchema,
+  ExecutionLogSchema,
+  CampaignStatusSchema,
+  StageStatusSchema,
+} from "@quillby/content";
+
+describe("CampaignStatusSchema", () => {
+  it("accepts all valid statuses", () => {
+    expect(CampaignStatusSchema.parse("planning")).toBe("planning");
+    expect(CampaignStatusSchema.parse("active")).toBe("active");
+    expect(CampaignStatusSchema.parse("paused")).toBe("paused");
+    expect(CampaignStatusSchema.parse("completed")).toBe("completed");
+    expect(CampaignStatusSchema.parse("failed")).toBe("failed");
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => CampaignStatusSchema.parse("invalid")).toThrow();
+    expect(() => CampaignStatusSchema.parse("")).toThrow();
+  });
+});
+
+describe("StageStatusSchema", () => {
+  it("accepts all valid statuses", () => {
+    expect(StageStatusSchema.parse("pending")).toBe("pending");
+    expect(StageStatusSchema.parse("running")).toBe("running");
+    expect(StageStatusSchema.parse("completed")).toBe("completed");
+    expect(StageStatusSchema.parse("failed")).toBe("failed");
+    expect(StageStatusSchema.parse("skipped")).toBe("skipped");
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => StageStatusSchema.parse("unknown")).toThrow();
+  });
+});
+
+describe("StageConfigSchema", () => {
+  it("accepts valid minimal config", () => {
+    const result = StageConfigSchema.parse({ name: "research", tool: "gather" });
+    expect(result.name).toBe("research");
+    expect(result.params).toEqual({});
+    expect(result.dependsOn).toEqual([]);
+    expect(result.retryCount).toBe(0);
+  });
+
+  it("accepts full config with all fields", () => {
+    const result = StageConfigSchema.parse({
+      name: "write",
+      tool: "composer",
+      params: { style: "formal" },
+      dependsOn: ["research"],
+      condition: "campaign.status === 'active'",
+      retryCount: 2,
+      timeout: 60000,
+    });
+    expect(result.params.style).toBe("formal");
+    expect(result.dependsOn).toEqual(["research"]);
+    expect(result.retryCount).toBe(2);
+    expect(result.timeout).toBe(60000);
+  });
+
+  it("rejects empty name", () => {
+    expect(() => StageConfigSchema.parse({ name: "", tool: "gather" })).toThrow();
+  });
+
+  it("rejects negative retryCount", () => {
+    expect(() => StageConfigSchema.parse({ name: "x", tool: "y", retryCount: -1 })).toThrow();
+  });
+
+  it("rejects non-integer retryCount", () => {
+    expect(() => StageConfigSchema.parse({ name: "x", tool: "y", retryCount: 1.5 })).toThrow();
+  });
+});
+
+describe("ExecutionLogSchema", () => {
+  it("accepts valid minimal log", () => {
+    const result = ExecutionLogSchema.parse({
+      stageName: "research",
+      status: "pending",
+    });
+    expect(result.retryAttempt).toBe(0);
+    expect(result.startedAt).toBeUndefined();
+  });
+
+  it("rejects empty stageName", () => {
+    expect(() => ExecutionLogSchema.parse({
+      stageName: "",
+      status: "pending",
+    })).toThrow();
+  });
+
+  it("accepts completed log with all fields", () => {
+    const result = ExecutionLogSchema.parse({
+      stageName: "write",
+      status: "completed",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      completedAt: "2026-01-01T01:00:00.000Z",
+      error: undefined,
+      result: { wordCount: 500 },
+      retryAttempt: 1,
+    });
+    expect(result.result!.wordCount).toBe(500);
+    expect(result.retryAttempt).toBe(1);
+  });
+
+  it("rejects invalid stage status", () => {
+    expect(() => ExecutionLogSchema.parse({
+      stageName: "x",
+      status: "unknown",
+    })).toThrow();
+  });
+
+  it("accepts failed log with error", () => {
+    const result = ExecutionLogSchema.parse({
+      stageName: "deploy",
+      status: "failed",
+      error: "Connection timeout",
+    });
+    expect(result.error).toBe("Connection timeout");
+  });
+});
+
+describe("BlueprintSchema", () => {
+  it("accepts valid blueprint", () => {
+    const result = BlueprintSchema.parse({
+      id: "bp-123",
+      name: "Weekly LinkedIn",
+      stages: [{ name: "research", tool: "gather" }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.description).toBe("");
+    expect(result.tags).toEqual([]);
+  });
+
+  it("accepts blueprint with all fields", () => {
+    const result = BlueprintSchema.parse({
+      id: "bp-456",
+      name: "Newsletter",
+      description: "Monthly newsletter pipeline",
+      stages: [
+        { name: "research", tool: "gather" },
+        { name: "write", tool: "composer", dependsOn: ["research"] },
+      ],
+      tags: ["newsletter", "monthly"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-02-01T00:00:00.000Z",
+    });
+    expect(result.stages).toHaveLength(2);
+    expect(result.tags).toHaveLength(2);
+  });
+
+  it("rejects blueprint without stages", () => {
+    expect(() => BlueprintSchema.parse({
+      id: "bp-1",
+      name: "Empty",
+      stages: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+
+  it("rejects missing name", () => {
+    expect(() => BlueprintSchema.parse({
+      id: "bp-1",
+      stages: [{ name: "x", tool: "y" }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+});
+
+describe("CampaignSchema", () => {
+  it("accepts valid minimal campaign", () => {
+    const result = CampaignSchema.parse({
+      id: "camp-123",
+      workspaceId: "default",
+      name: "Test Campaign",
+      status: "planning",
+      stages: [{ name: "research", tool: "gather" }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.executions).toEqual([]);
+    expect(result.blueprintId).toBe("");
+  });
+
+  it("accepts campaign with executions", () => {
+    const result = CampaignSchema.parse({
+      id: "camp-456",
+      workspaceId: "ws-1",
+      blueprintId: "bp-1",
+      name: "Active Campaign",
+      status: "active",
+      stages: [{ name: "research", tool: "gather" }],
+      executions: [{ stageName: "research", status: "running", startedAt: "2026-01-01T00:00:00.000Z" }],
+      startedAt: "2026-01-01T00:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.executions).toHaveLength(1);
+    expect(result.startedAt).toBeDefined();
+  });
+
+  it("accepts completed campaign", () => {
+    const result = CampaignSchema.parse({
+      id: "camp-789",
+      workspaceId: "default",
+      name: "Done",
+      status: "completed",
+      stages: [{ name: "stage1", tool: "t" }],
+      executions: [{ stageName: "stage1", status: "completed", completedAt: "2026-01-01T01:00:00.000Z" }],
+      completedAt: "2026-01-01T01:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T01:00:00.000Z",
+    });
+    expect(result.completedAt).toBeDefined();
+  });
+
+  it("accepts failed campaign with error", () => {
+    const result = CampaignSchema.parse({
+      id: "camp-fail",
+      workspaceId: "default",
+      name: "Failed",
+      status: "failed",
+      stages: [{ name: "deploy", tool: "t" }],
+      executions: [{ stageName: "deploy", status: "failed", error: "Timeout" }],
+      error: "Timeout",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.error).toBe("Timeout");
+  });
+
+  it("rejects invalid campaign status", () => {
+    expect(() => CampaignSchema.parse({
+      id: "camp-1",
+      workspaceId: "default",
+      name: "Bad",
+      status: "unknown",
+      stages: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() => CampaignSchema.parse({
+      id: "camp-1",
+      workspaceId: "default",
+      name: "",
+      status: "planning",
+      stages: [{ name: "x", tool: "y" }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+
+  it("rejects empty workspaceId", () => {
+    expect(() => CampaignSchema.parse({
+      id: "camp-1",
+      workspaceId: "",
+      name: "Test",
+      status: "planning",
+      stages: [{ name: "x", tool: "y" }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+
+  it("rejects empty stages array", () => {
+    expect(() => CampaignSchema.parse({
+      id: "camp-1",
+      workspaceId: "default",
+      name: "No Stages",
+      status: "planning",
+      stages: [],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+
+  it("rejects empty id", () => {
+    expect(() => CampaignSchema.parse({
+      id: "",
+      workspaceId: "default",
+      name: "Test",
+      status: "planning",
+      stages: [{ name: "x", tool: "y" }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    })).toThrow();
+  });
+});

--- a/apps/mcp-server/tests/unit/campaign-store-fs.test.ts
+++ b/apps/mcp-server/tests/unit/campaign-store-fs.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  createCampaign,
+  loadCampaign,
+  listCampaigns,
+  updateCampaign,
+  deleteCampaign,
+  saveBlueprint,
+  loadBlueprint,
+  listBlueprints,
+  deleteBlueprint,
+} from "@quillby/storage-fs";
+import {
+  createWorkspace,
+  ensureWorkspaceSystem,
+} from "@quillby/workspace";
+
+let tempHome: string;
+let previousHome: string | undefined;
+const wsId = "test-ws";
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+function makeCampaign(id = "camp-1"): Parameters<typeof createCampaign>[0] {
+  return {
+    id,
+    workspaceId: wsId,
+    blueprintId: "bp-1",
+    name: `Campaign ${id}`,
+    status: "planning",
+    stages: [{ name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 0 }],
+    executions: [],
+    createdAt: ts(),
+    updatedAt: ts(),
+  };
+}
+
+function makeBlueprint(id = "bp-1"): Parameters<typeof saveBlueprint>[0] {
+  return {
+    id,
+    name: `Blueprint ${id}`,
+    description: "",
+    stages: [{ name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 0 }],
+    tags: [],
+    createdAt: ts(),
+    updatedAt: ts(),
+  };
+}
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "quillby-campaign-store-"));
+  previousHome = process.env.QUILLBY_HOME;
+  process.env.QUILLBY_HOME = tempHome;
+  ensureWorkspaceSystem();
+  createWorkspace({ id: wsId, name: "Test Workspace" });
+});
+
+afterEach(() => {
+  if (previousHome === undefined) {
+    delete process.env.QUILLBY_HOME;
+  } else {
+    process.env.QUILLBY_HOME = previousHome;
+  }
+  fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("Campaign store (filesystem)", () => {
+  describe("createCampaign", () => {
+    it("writes a campaign file", () => {
+      createCampaign(makeCampaign(), wsId);
+      const loaded = loadCampaign("camp-1", wsId);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.name).toBe("Campaign camp-1");
+    });
+
+    it("validates the campaign before writing", () => {
+      expect(() => createCampaign(
+        { ...makeCampaign(), id: "", workspaceId: wsId, name: "Bad" },
+        wsId,
+      )).toThrow();
+    });
+  });
+
+  describe("loadCampaign", () => {
+    it("returns null for missing campaign", () => {
+      expect(loadCampaign("nonexistent", wsId)).toBeNull();
+    });
+
+    it("returns null for corrupted file", () => {
+      const dir = path.join(tempHome, "workspaces", wsId, "campaigns");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "campaign-bad.json"), "not json");
+      expect(loadCampaign("bad", wsId)).toBeNull();
+    });
+  });
+
+  describe("listCampaigns", () => {
+    it("returns empty list when no campaigns", () => {
+      expect(listCampaigns(undefined, wsId)).toEqual([]);
+    });
+
+    it("returns all campaigns", () => {
+      createCampaign(makeCampaign("c1"), wsId);
+      createCampaign(makeCampaign("c2"), wsId);
+      const all = listCampaigns(undefined, wsId);
+      expect(all).toHaveLength(2);
+    });
+
+    it("filters by status", () => {
+      const active = makeCampaign("c1");
+      active.status = "active";
+      createCampaign(active, wsId);
+      createCampaign(makeCampaign("c2"), wsId);
+      const result = listCampaigns("active", wsId);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("c1");
+    });
+  });
+
+  describe("updateCampaign", () => {
+    it("updates campaign fields", () => {
+      createCampaign(makeCampaign(), wsId);
+      updateCampaign("camp-1", { name: "Updated Name" }, wsId);
+      const loaded = loadCampaign("camp-1", wsId);
+      expect(loaded!.name).toBe("Updated Name");
+    });
+
+    it("updates campaign status", () => {
+      createCampaign(makeCampaign(), wsId);
+      updateCampaign("camp-1", { status: "active" }, wsId);
+      const loaded = loadCampaign("camp-1", wsId);
+      expect(loaded!.status).toBe("active");
+    });
+
+    it("throws on missing campaign", () => {
+      expect(() => updateCampaign("nonexistent", { name: "X" }, wsId)).toThrow("not found");
+    });
+  });
+
+  describe("deleteCampaign", () => {
+    it("deletes existing campaign", () => {
+      createCampaign(makeCampaign(), wsId);
+      deleteCampaign("camp-1", wsId);
+      expect(loadCampaign("camp-1", wsId)).toBeNull();
+    });
+
+    it("does not throw on missing campaign", () => {
+      expect(() => deleteCampaign("nonexistent", wsId)).not.toThrow();
+    });
+  });
+
+  describe("blueprint CRUD", () => {
+    it("saves and loads a blueprint", () => {
+      saveBlueprint(makeBlueprint(), wsId);
+      const loaded = loadBlueprint("bp-1", wsId);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.name).toBe("Blueprint bp-1");
+    });
+
+    it("returns null for missing blueprint", () => {
+      expect(loadBlueprint("nonexistent", wsId)).toBeNull();
+    });
+
+    it("lists all blueprints", () => {
+      saveBlueprint(makeBlueprint("bp-1"), wsId);
+      saveBlueprint(makeBlueprint("bp-2"), wsId);
+      expect(listBlueprints(wsId)).toHaveLength(2);
+    });
+
+    it("deletes a blueprint", () => {
+      saveBlueprint(makeBlueprint(), wsId);
+      deleteBlueprint("bp-1", wsId);
+      expect(loadBlueprint("bp-1", wsId)).toBeNull();
+    });
+
+    it("validates blueprint before saving", () => {
+      expect(() => saveBlueprint(
+        { ...makeBlueprint(), stages: [] },
+        wsId,
+      )).toThrow();
+    });
+  });
+
+  describe("data isolation", () => {
+    it("isolates campaigns between workspace IDs", () => {
+      createWorkspace({ id: "ws-a", name: "Workspace A" });
+      createWorkspace({ id: "ws-b", name: "Workspace B" });
+      createCampaign(makeCampaign("c1"), "ws-a");
+      createCampaign(makeCampaign("c2"), "ws-b");
+      expect(listCampaigns(undefined, "ws-a")).toHaveLength(1);
+      expect(listCampaigns(undefined, "ws-b")).toHaveLength(1);
+    });
+  });
+});

--- a/apps/mcp-server/tests/unit/mcp-campaigns.test.ts
+++ b/apps/mcp-server/tests/unit/mcp-campaigns.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleCampaignTool, CAMPAIGN_TOOL_NAMES } from "../../src/mcp/tools/campaigns.js";
+import type { CampaignStore } from "@quillby/workspace";
+import type { ToolContext } from "../../src/mcp/tools/index.js";
+import type { Campaign, Blueprint } from "@quillby/content";
+
+function mockStore(): CampaignStore {
+  const campaigns = new Map<string, Campaign>();
+  const blueprints = new Map<string, Blueprint>();
+  return {
+    createCampaign: vi.fn(async (c: Campaign) => { campaigns.set(c.id, c); }),
+    loadCampaign: vi.fn(async (id: string) => campaigns.get(id) ?? null),
+    listCampaigns: vi.fn(async (status?: string) =>
+      [...campaigns.values()].filter((c) => !status || c.status === status),
+    ),
+    updateCampaign: vi.fn(async (id: string, patch: Partial<Campaign>) => {
+      const existing = campaigns.get(id);
+      if (!existing) throw new Error(`Campaign "${id}" not found.`);
+      campaigns.set(id, { ...existing, ...patch, updatedAt: new Date().toISOString() });
+    }),
+    deleteCampaign: vi.fn(async (id: string) => { campaigns.delete(id); }),
+    saveBlueprint: vi.fn(async (b: Blueprint) => { blueprints.set(b.id, b); }),
+    loadBlueprint: vi.fn(async (id: string) => blueprints.get(id) ?? null),
+    listBlueprints: vi.fn(async () => [...blueprints.values()]),
+    deleteBlueprint: vi.fn(async (id: string) => { blueprints.delete(id); }),
+  };
+}
+
+function mockContext(store: CampaignStore): ToolContext {
+  const storeWithOverrides = Object.assign(store, {
+    getCurrentWorkspaceId: vi.fn().mockResolvedValue("default"),
+    withWorkspace: vi.fn().mockResolvedValue(store),
+  }) satisfies CampaignStore;
+  return {
+    server: {} as ToolContext["server"],
+    storage: storeWithOverrides as unknown as ToolContext["storage"],
+    deploymentMode: "local" as const,
+    providerRouter: {} as ToolContext["providerRouter"],
+    sample: vi.fn().mockResolvedValue(null),
+  };
+}
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+describe("CAMPAIGN_TOOL_NAMES", () => {
+  it("contains all expected tool names", () => {
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_create")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_start")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_status")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_pause")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_stage_complete")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_stage_fail")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_stage_retry")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_blueprint_create")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_blueprint_list")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.has("campaign_list")).toBe(true);
+    expect(CAMPAIGN_TOOL_NAMES.size).toBe(10);
+  });
+});
+
+describe("handleCampaignTool — campaign_create", () => {
+  it("creates a campaign from inline stages", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_create", {
+      name: "Test Campaign",
+      blueprint: [{ name: "research", tool: "gather" }],
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { campaign: Campaign };
+    expect(data.campaign.name).toBe("Test Campaign");
+    expect(data.campaign.status).toBe("planning");
+    expect(data.campaign.stages).toHaveLength(1);
+  });
+
+  it("creates a campaign from a saved blueprint", async () => {
+    const store = mockStore();
+    await store.saveBlueprint({
+      id: "bp-1", name: "BP", description: "", stages: [
+        { name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 0 },
+      ], tags: [], createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_create", {
+      name: "From Blueprint",
+      blueprintId: "bp-1",
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as { campaign: Campaign }).campaign.stages).toHaveLength(1);
+  });
+
+  it("returns error when blueprint not found", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_create", {
+      name: "Missing BP",
+      blueprintId: "bp-nonexistent",
+    }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+  });
+
+  it("returns error for invalid args", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_create", {}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Invalid arguments");
+  });
+});
+
+describe("handleCampaignTool — campaign_start", () => {
+  it("starts a planning campaign", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "planning",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "pending", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_start", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { status: string };
+    expect(data.status).toBe("active");
+  });
+
+  it("returns error when campaign not found", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_start", { campaignId: "nonexistent" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+  });
+
+  it("starts a paused campaign", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Paused", status: "paused",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "pending", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_start", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as { status: string }).status).toBe("active");
+  });
+
+  it("starts a failed campaign", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Failed", status: "failed",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "failed", retryAttempt: 0, error: "E" }],
+      createdAt: ts(), updatedAt: ts(), error: "E",
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_start", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as { status: string }).status).toBe("active");
+  });
+
+  it("returns error when campaign is already active", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Active", status: "active",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_start", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Cannot start");
+  });
+});
+
+describe("handleCampaignTool — campaign_status", () => {
+  it("returns campaign status", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "active",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_status", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("active");
+    expect(result.structuredContent).toBeDefined();
+  });
+
+  it("returns error for missing campaign", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_status", { campaignId: "nonexistent" }, ctx);
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("handleCampaignTool — campaign_pause", () => {
+  it("pauses an active campaign", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Active", status: "active",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_pause", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect((result.structuredContent as { status: string }).status).toBe("paused");
+  });
+
+  it("returns error when campaign is not active", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Planning", status: "planning",
+      stages: [], executions: [], createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_pause", { campaignId: "camp-1" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Cannot pause");
+  });
+});
+
+describe("handleCampaignTool — campaign_stage_complete", () => {
+  it("completes an already-completed stage", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "active",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "completed", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_complete", {
+      campaignId: "camp-1", stageName: "s1",
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("All stages complete");
+  });
+
+  it("completes a stage", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "active",
+      stages: [{ name: "research", tool: "gather", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "research", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_complete", {
+      campaignId: "camp-1", stageName: "research", result: { data: "ok" },
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("All stages complete");
+  });
+
+  it("returns error for nonexistent stage", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "active",
+      stages: [{ name: "real", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "real", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_complete", {
+      campaignId: "camp-1", stageName: "imaginary",
+    }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+  });
+});
+
+describe("handleCampaignTool — campaign_stage_fail", () => {
+  it("fails an already-failed stage", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "failed",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "failed", retryAttempt: 0, error: "Prev error" }],
+      createdAt: ts(), updatedAt: ts(), error: "Prev error",
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_fail", {
+      campaignId: "camp-1", stageName: "s1", error: "Again",
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("failed");
+  });
+
+  it("fails a stage", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "active",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_fail", {
+      campaignId: "camp-1", stageName: "s1", error: "Something broke",
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("failed");
+  });
+
+  it("reports campaign-level failure when stage fails", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "active",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 2 }],
+      executions: [{ stageName: "s1", status: "running", retryAttempt: 0 }],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_fail", {
+      campaignId: "camp-1", stageName: "s1", error: "Retry this",
+    }, ctx);
+    expect(result.content[0]!.text).toContain("failed");
+    expect(result.content[0]!.text).toContain("Campaign failed");
+  });
+});
+
+describe("handleCampaignTool — campaign_stage_retry", () => {
+  it("resets a failed stage to pending and increments retry", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "failed",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 2 }],
+      executions: [{ stageName: "s1", status: "failed", retryAttempt: 0, error: "Error" }],
+      createdAt: ts(), updatedAt: ts(), error: "Error",
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_retry", {
+      campaignId: "camp-1", stageName: "s1",
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("attempt 1");
+  });
+
+  it("returns error when retries exhausted", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "camp-1", workspaceId: "default", blueprintId: "", name: "Test", status: "failed",
+      stages: [{ name: "s1", tool: "t", params: {}, dependsOn: [], retryCount: 0 }],
+      executions: [{ stageName: "s1", status: "failed", retryAttempt: 0, error: "Error" }],
+      createdAt: ts(), updatedAt: ts(), error: "Error",
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_stage_retry", {
+      campaignId: "camp-1", stageName: "s1",
+    }, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("cannot be retried");
+  });
+});
+
+describe("handleCampaignTool — blueprint tools", () => {
+  it("creates a blueprint via campaign_blueprint_create", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_blueprint_create", {
+      name: "Daily Brief",
+      description: "My blueprint",
+      stages: [{ name: "fetch", tool: "reader" }],
+      tags: ["daily"],
+    }, ctx);
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { blueprint: Blueprint };
+    expect(data.blueprint.name).toBe("Daily Brief");
+    expect(data.blueprint.stages).toHaveLength(1);
+  });
+
+  it("lists blueprints via campaign_blueprint_list", async () => {
+    const store = mockStore();
+    await store.saveBlueprint({
+      id: "bp-1", name: "BP1", description: "", stages: [], tags: [],
+      createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_blueprint_list", {}, ctx);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0]!.text).toContain("BP1");
+  });
+
+  it("shows empty message when no blueprints", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_blueprint_list", {}, ctx);
+    expect(result.content[0]!.text).toBe("No blueprints saved.");
+  });
+
+  it("returns error for invalid blueprint create args", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_blueprint_create", {}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Invalid arguments");
+  });
+});
+
+describe("handleCampaignTool — campaign_list", () => {
+  it("lists campaigns with status filter", async () => {
+    const store = mockStore();
+    await store.createCampaign({
+      id: "c1", workspaceId: "default", blueprintId: "", name: "Active", status: "active",
+      stages: [], executions: [], createdAt: ts(), updatedAt: ts(),
+    });
+    await store.createCampaign({
+      id: "c2", workspaceId: "default", blueprintId: "", name: "Planning", status: "planning",
+      stages: [], executions: [], createdAt: ts(), updatedAt: ts(),
+    });
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_list", { status: "active" }, ctx);
+    expect(result.content[0]!.text).toContain("Active");
+    expect(result.content[0]!.text).not.toContain("Planning");
+  });
+
+  it("shows empty message when no campaigns", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_list", {}, ctx);
+    expect(result.content[0]!.text).toBe("No campaigns found.");
+  });
+});
+
+describe("handleCampaignTool — unknown tool", () => {
+  it("returns error for unknown tool name", async () => {
+    const store = mockStore();
+    const ctx = mockContext(store);
+    const result = await handleCampaignTool("campaign_unknown", {}, ctx);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Unknown campaign tool");
+  });
+});

--- a/packages/content/src/campaign/types.ts
+++ b/packages/content/src/campaign/types.ts
@@ -29,7 +29,7 @@ export const BlueprintSchema = z.object({
 export type Blueprint = z.infer<typeof BlueprintSchema>;
 
 export const ExecutionLogSchema = z.object({
-  stageName: z.string(),
+  stageName: z.string().min(1),
   status: StageStatusSchema,
   startedAt: z.string().optional(),
   completedAt: z.string().optional(),
@@ -41,11 +41,11 @@ export type ExecutionLog = z.infer<typeof ExecutionLogSchema>;
 
 export const CampaignSchema = z.object({
   id: z.string().min(1),
-  workspaceId: z.string(),
+  workspaceId: z.string().min(1),
   blueprintId: z.string().optional().default(""),
   name: z.string().min(1),
   status: CampaignStatusSchema,
-  stages: z.array(StageConfigSchema),
+  stages: z.array(StageConfigSchema).min(1),
   executions: z.array(ExecutionLogSchema).default([]),
   createdAt: z.string(),
   updatedAt: z.string(),


### PR DESCRIPTION
Adds 102 tests across 4 files covering:
- Campaign/Blueprint/StageConfig/ExecutionLog Zod schema validation
- Pipeline executor: transitionStage, areDependenciesMet, getNextStages, checkAllCompleted, canRetryStage, initialExecutionLogs
- Edge cases: circular dependencies, all-skipped, retry exhaustion, timeout/condition preservation
- Filesystem CampaignStore CRUD with temp QUILLBY_HOME isolation
- MCP handler tests for all 10 tools with mocked CampaignStore

Also fixes schema validation holes:
- ExecutionLogSchema.stageName: z.string().min(1)
- CampaignSchema.workspaceId: z.string().min(1)
- CampaignSchema.stages: z.array(...).min(1)

Closes T-000534