### PR TITLE
docs(ops): add self-hosted operations runbook

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -17,6 +17,8 @@ pnpm build
 
 `./apps/mcp-server/bin/quillby-mcp` is the canonical entrypoint after building.
 
+For **self-hosted HTTP deployments**, see [docs/operations/deployment.md](operations/deployment.md) for Docker Compose setup, environment configuration, reverse proxy, and user management.
+
 ## Tools
 
 **For Claude Desktop user setup, see [README.md](../README.md).**

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,3 +1,11 @@
 # Operations
 
-Self-hosting, deployment, release, and incident-response documentation belongs here.
+Self-hosting, deployment, release, and incident-response documentation.
+
+| Document | Description |
+|---|---|
+| [Deployment Guide](deployment.md) | Docker Compose setup, env vars, reverse proxy, MCP client config |
+| [Backups](backups.md) | Database backup/restore for local SQLite and remote Turso |
+| [Upgrades](upgrades.md) | Version upgrades, migration process, rollback |
+| [Disaster Recovery](disaster-recovery.md) | Recovery procedures for common failure scenarios |
+| [Secrets Management](secrets.md) | Credential handling, encryption, and rotation |

--- a/docs/operations/backups.md
+++ b/docs/operations/backups.md
@@ -1,0 +1,89 @@
+# Backups
+
+## Local SQLite (Docker Volume)
+
+The default setup stores the auth database in a Docker volume (`quillby_data`).
+
+### One-shot Backup
+
+```bash
+docker run --rm -v quillby_data:/data -v $(pwd):/backup alpine \
+  tar czf /backup/quillby-backup-$(date +%Y%m%d-%H%M%S).tar.gz /data
+```
+
+### Restore
+
+```bash
+docker run --rm -v quillby_data:/data -v $(pwd):/backup alpine \
+  tar xzf /backup/quillby-backup-20260101-120000.tar.gz -C /
+docker compose restart quillby
+```
+
+### Automated Backup (cron)
+
+Create a cron job on the host:
+
+```crontab
+# Daily at 3 AM — keep last 30 backups
+0 3 * * * /usr/local/bin/quillby-backup
+```
+
+Create `/usr/local/bin/quillby-backup`:
+
+```bash
+#!/bin/bash
+BACKUP_DIR=/var/backups/quillby
+RETENTION_DAYS=30
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+
+mkdir -p "$BACKUP_DIR"
+docker run --rm -v quillby_data:/data -v "$BACKUP_DIR":/backup alpine \
+  tar czf "/backup/quillby-backup-$TIMESTAMP.tar.gz" /data
+
+# Prune old backups
+find "$BACKUP_DIR" -name "quillby-backup-*.tar.gz" -mtime +$RETENTION_DAYS -delete
+```
+
+## Remote libSQL / Turso
+
+### Backup
+
+```bash
+turso db shell quillby .dump > quillby-dump-$(date +%Y%m%d).sql
+```
+
+### Restore
+
+```bash
+# Create a new database from the dump
+turso db create quillby-restored
+turso db shell quillby-restored < quillby-dump-20260101.sql
+
+# Update your .env to point at the restored database
+# QUILLBY_AUTH_DB_URL=libsql://quillby-restored-<org>.turso.io
+```
+
+### Automated Backup
+
+```bash
+#!/bin/bash
+BACKUP_DIR=/var/backups/quillby
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$BACKUP_DIR"
+turso db shell quillby .dump > "$BACKUP_DIR/quillby-dump-$TIMESTAMP.sql"
+# Optionally sync off-site
+rclone copy "$BACKUP_DIR" remote:backups/quillby/
+```
+
+## Verification
+
+Periodically verify your backups by restoring to a temporary location:
+
+```bash
+# Restore local backup to temp dir
+mkdir /tmp/quillby-restore-test
+docker run --rm -v quillby_data:/data -v /tmp/quillby-restore-test:/restore alpine \
+  tar xzf /var/backups/quillby/quillby-backup-20260101-120000.tar.gz -C /restore
+# Verify the file structure
+ls -la /tmp/quillby-restore-test/data/
+```

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,155 @@
+# Self-Hosted Deployment
+
+This guide covers deploying Quillby in **self-hosted (HTTP) mode** — your own server, behind your own reverse proxy, with persistent storage, backups, and monitoring.
+
+## Prerequisites
+
+- Docker & Docker Compose (v2+)
+- A domain name pointing to your server (for TLS)
+- 1 GB RAM, 1 CPU minimum
+- Ports 80/443 (reverse proxy) and optionally 3000 (direct)
+
+## Quick Start
+
+```bash
+# 1. Clone or download Quillby
+git clone https://github.com/vncsleal/quillby.git
+cd quillby/infra/docker
+
+# 2. Configure
+cp .env.example .env
+# Edit .env — at minimum set BETTER_AUTH_SECRET
+# Generate with: openssl rand -base64 32
+
+# 3. Start
+docker compose up -d
+
+# 4. Create your first user and API key
+docker exec -it quillby node /app/dist/cli/keys.js create-user admin@example.com "Your Password" "Admin User"
+docker exec -it quillby node /app/dist/cli/keys.js create <userId> quillby-connector
+```
+
+The second command prints the API key — copy it now, it is only shown once.
+
+## Environment Variables Reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `QUILLBY_TRANSPORT` | — | `http` | Transport mode. Must be `http` for self-hosted. |
+| `PORT` | — | `3000` | Internal HTTP port (behind reverse proxy) |
+| `QUILLBY_HTTP_HOST` | — | `0.0.0.0` | Bind address |
+| `QUILLBY_BASE_URL` | **Yes** | `http://localhost:3000` | Public URL of your instance. Used for CORS, redirects, and MCP agent discovery. Must include protocol and no trailing slash. |
+| `BETTER_AUTH_SECRET` | **Yes** | — | Auth signing key. Generate: `openssl rand -base64 32` |
+| `BETTER_AUTH_URL` | — | `http://localhost:3000` | Must match QUILLBY_BASE_URL in production |
+| `QUILLBY_AUTH_DB_URL` | — | `file:/data/quillby-auth.db` | Local SQLite or remote libSQL/Turso URL |
+| `LIBSQL_AUTH_TOKEN` | — | — | Required when using remote Turso as auth DB |
+| `QUILLBY_RATE_LIMIT` | — | `60` | Default max requests/minute for new API keys |
+| `QUILLBY_DEPLOYMENT_MODE` | — | `self-hosted` | Set automatically by docker-compose |
+| `QUILLBY_SMTP_HOST` | — | — | SMTP server for email verification + password reset |
+| `QUILLBY_SMTP_PORT` | — | `587` | SMTP port |
+| `QUILLBY_SMTP_USER` | — | — | SMTP username |
+| `QUILLBY_SMTP_PASS` | — | — | SMTP password |
+| `QUILLBY_SMTP_FROM` | — | — | From address for outgoing emails |
+| `QUILLBY_PROVIDER_ENCRYPTION_KEY` | — | — | Encrypts provider API keys stored via Settings UI. Generate: `openssl rand -base64 32` |
+| `QUILLBY_REPLICATE_API_TOKEN` | — | — | Single token for image/audio/video generation via Replicate |
+| `QUILLBY_OPENAI_API_KEY` | — | — | For GPT-Image generation |
+| `QUILLBY_ELEVENLABS_API_KEY` | — | — | For ElevenLabs TTS + voice cloning |
+| `QUILLBY_FAL_API_KEY` | — | — | For fal.ai Kling video generation |
+
+## Reverse Proxy
+
+Quillby exposes HTTP on port 3000. In production, put it behind a reverse proxy for TLS termination.
+
+### Caddy (recommended — automatic TLS)
+
+```caddyfile
+quillby.example.com {
+    reverse_proxy quillby:3000
+}
+```
+
+### Nginx
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name quillby.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/.../fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/.../privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Traefik (Docker-native)
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.quillby.rule=Host(`quillby.example.com`)"
+  - "traefik.http.services.quillby.loadbalancer.server.port=3000"
+```
+
+## Health Checks
+
+The container includes a health check at `/health`:
+
+```bash
+curl http://localhost:3000/health
+# {"status":"ok","uptime":1234}
+```
+
+## MCP Client Configuration
+
+See [MCP.md](../MCP.md) for client-specific setup guides.
+
+For a remote self-hosted instance, configure your MCP client with the HTTP URL of the `/mcp` endpoint:
+
+```json
+{
+  "mcpServers": {
+    "quillby": {
+      "type": "url",
+      "url": "https://quillby.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}
+```
+
+## Container Lifecycle
+
+```bash
+# View logs
+docker compose logs -f quillby
+
+# Restart
+docker compose restart quillby
+
+# Stop
+docker compose down
+
+# Stop + remove volume (destroys all data)
+docker compose down -v
+
+# Rebuild from source (after pulling new code)
+docker compose build --no-cache quillby
+```
+
+## User & Key Management
+
+```bash
+# Create user
+docker exec -it quillby node /app/dist/cli/keys.js create-user <email> <password> <name>
+
+# Create API key
+docker exec -it quillby node /app/dist/cli/keys.js create <userId> <description>
+```

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -1,0 +1,123 @@
+# Disaster Recovery
+
+## Scenarios
+
+### 1. Corrupted Auth Database
+
+**Symptoms:** Server fails to start; logs show database errors.
+
+**Resolution:**
+
+```bash
+# 1. Stop the container
+docker compose down
+
+# 2. Restore from the most recent backup
+# (see backups.md for restore procedures)
+
+# 3. If no backup exists, create a fresh database and re-create users
+docker compose up -d
+docker exec -it quillby node /app/dist/cli/keys.js create-user admin@example.com "new-password" "Admin"
+```
+
+### 2. Lost Docker Volume
+
+**Symptoms:** Container starts but no users or data exist.
+
+**Resolution:**
+
+```bash
+# 1. Check if volume still exists
+docker volume ls | grep quillby_data
+
+# 2. If missing, restore from backup (see backups.md)
+
+# 3. If no backup exists:
+docker compose up -d
+# Re-create users and API keys via the CLI
+```
+
+### 3. Failed Migration
+
+**Symptoms:** Server exits on startup; logs show migration error.
+
+**Resolution:**
+
+```bash
+# 1. Check the migration error
+docker compose logs quillby | grep -i "migration\|error"
+
+# 2. Roll back to the previous version (see upgrades.md)
+
+# 3. If the migration partially applied, restore from backup first
+# then roll back the version
+```
+
+### 4. Hardware Failure
+
+**Symptoms:** Server is unreachable; data may be on corrupted disk.
+
+**Resolution:**
+
+1. Provision a new server.
+2. Install Docker and Docker Compose.
+3. Copy the backup archive to the new server.
+4. Restore the data volume:
+   ```bash
+   # Create the volume
+   docker volume create quillby_data
+
+   # Restore backup into it
+   docker run --rm -v quillby_data:/data -v /path/to/backup:/backup alpine \
+     tar xzf /backup/quillby-backup-20260101-120000.tar.gz -C /
+   ```
+5. Start the container:
+   ```bash
+   docker compose up -d
+   ```
+
+### 5. Misconfiguration
+
+**Symptoms:** Server starts but behaves incorrectly (wrong URL, auth errors, CORS issues).
+
+**Resolution:**
+
+1. Check the environment:
+   ```bash
+   docker compose config
+   ```
+2. Verify key settings:
+   - `QUILLBY_BASE_URL` matches the actual public URL.
+   - `BETTER_AUTH_URL` matches `QUILLBY_BASE_URL`.
+   - `BETTER_AUTH_SECRET` is set.
+3. Restart after fixing:
+   ```bash
+   docker compose restart quillby
+   ```
+
+## Complete Rebuild from Scratch
+
+If all data is lost, start fresh:
+
+```bash
+# 1. Destroy everything
+docker compose down -v
+
+# 2. Start clean
+docker compose up -d
+
+# 3. Create admin user
+docker exec -it quillby node /app/dist/cli/keys.js create-user admin@example.com "password" "Admin"
+
+# 4. Create an API key
+docker exec -it quillby node /app/dist/cli/keys.js create <userId> quillby-connector
+```
+
+## Prevention Checklist
+
+- [ ] Automated daily backups configured (see [backups.md](backups.md))
+- [ ] Backup retention policy set (minimum 30 days)
+- [ ] Off-site backup copy configured (rclone, S3, or similar)
+- [ ] Health check monitoring in place
+- [ ] Restore procedure tested at least quarterly
+- [ ] Reverse proxy timeout configured (recommended: 60s for MCP long-polling)

--- a/docs/operations/upgrades.md
+++ b/docs/operations/upgrades.md
@@ -1,0 +1,81 @@
+# Upgrades
+
+## Standard Upgrade
+
+```bash
+cd path/to/quillby/infra/docker
+docker compose pull
+docker compose up -d
+```
+
+Database migrations run automatically on startup. No manual migration commands are needed for standard upgrades.
+
+## How Migrations Work
+
+On every startup, the server calls `ensureHostedTables()` which:
+
+1. Checks if a `_schema_version` table exists in the auth database.
+2. If not, creates it and runs all pending migrations sequentially.
+3. Logs each migration step with its version number.
+4. If a migration fails, the server exits with a non-zero code — the container will restart and retry.
+
+Check migration status from the logs:
+
+```bash
+docker compose logs quillby | grep -i migration
+```
+
+## Manual Migration
+
+If you need to run migrations manually (e.g., during debugging):
+
+```bash
+docker exec -it quillby node /app/dist/cli/migrate.js
+```
+
+## Major Version Upgrades
+
+1. **Read the release notes** — breaking changes are documented in the changelog.
+2. **Back up your data** before upgrading (see [backups.md](backups.md)).
+3. **Pull the new image** and restart:
+   ```bash
+   docker compose pull && docker compose up -d
+   ```
+4. **Verify** the server is healthy:
+   ```bash
+   curl http://localhost:3000/health
+   ```
+5. **Check the logs** for any migration warnings or errors:
+   ```bash
+   docker compose logs quillby | tail -50
+   ```
+
+## Rollback
+
+If an upgrade fails:
+
+1. Stop the container:
+   ```bash
+   docker compose down
+   ```
+2. Restore the previous image tag (if using a specific tag):
+   ```bash
+   # In docker-compose.yml, set image: vncsleal/quillby:<previous-version>
+   docker compose pull
+   docker compose up -d
+   ```
+3. If you use `latest`, pull the previous version explicitly:
+   ```bash
+   docker pull vncsleal/quillby:<previous-version>
+   docker tag vncsleal/quillby:<previous-version> vncsleal/quillby:latest
+   docker compose up -d
+   ```
+
+## Breaking Changes Policy
+
+Breaking changes are communicated via:
+- **GitHub releases** — annotated with `BREAKING` prefix
+- **Changelog** — kept in `CHANGELOG.md` at the repository root
+- **Migration notes** — included in the release body
+
+Before a major version bump (v1 → v2, etc.), a deprecation notice will be posted at least one minor version in advance.

--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -30,6 +30,14 @@ QUILLBY_AUTH_DB_URL=file:/data/quillby-auth.db
 # QUILLBY_AUTH_DB_URL=libsql://<db-name>-<org>.turso.io
 # LIBSQL_AUTH_TOKEN=<token from: turso db tokens create <db-name>>
 
+# ── SMTP (optional — enables email verification + password reset) ────────────────
+# Without SMTP, verification/password-reset emails are logged to stdout only.
+# QUILLBY_SMTP_HOST=smtp.example.com
+# QUILLBY_SMTP_PORT=587
+# QUILLBY_SMTP_USER=
+# QUILLBY_SMTP_PASS=
+# QUILLBY_SMTP_FROM=quillby@example.com
+
 # ── Rate limiting ──────────────────────────────────────────────────────────────
 
 # Default max requests per minute for newly created API keys.


### PR DESCRIPTION
## Adds 4 runbook documents + SMTP env vars + cross-reference

### Files

| File | Content |
|---|---|
| `docs/operations/deployment.md` | Docker Compose setup, env var reference table, reverse proxy (Caddy/Nginx/Traefik), health checks, MCP client config, container lifecycle, user/key management |
| `docs/operations/backups.md` | Local SQLite and remote Turso backup/restore, automated cron scripts, off-site sync, verification |
| `docs/operations/upgrades.md` | Standard upgrade, migration process, major version upgrades, rollback, breaking changes policy |
| `docs/operations/disaster-recovery.md` | 5 recovery scenarios: corrupted DB, lost volume, failed migration, hardware failure, misconfiguration + prevention checklist |
| `docs/operations/README.md` | Updated table of contents linking all 5 docs |
| `infra/docker/.env.example` | Added SMTP section with 5 commented vars |
| `docs/MCP.md` | Cross-reference to deployment.md for self-hosted users |

Closes T-000561