### PR TITLE
fix: export SamplingHost interface to unblock CI typecheck

### DIFF
--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -74,6 +74,7 @@ import {
   getProviderPolicyReport,
   validateUrl,
 } from "@quillby/providers";
+import type { SamplingHost } from "@quillby/providers";
 import type { GenerationModality } from "@quillby/core";
 import {
   GenerateImageArgsSchema,
@@ -3239,7 +3240,7 @@ if (TRANSPORT_MODE === "http") {
   // via the Server's createMessage() method (public API on the MCP Server class).
   try {
     const assetsDir = path.join(process.env.QUILLBY_HOME ?? process.env.HOME ?? "~", ".quillby", "assets");
-    providerRouter.setTier1(new McpSamplingAdapter(server.server, assetsDir));
+    providerRouter.setTier1(new McpSamplingAdapter(server.server as SamplingHost, assetsDir));
   } catch (e) {
     logWarn("McpSamplingAdapter init failed (generation falls through to Tier 2)", { error: String(e) });
   }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -7,6 +7,7 @@ export type {
 } from "./router.js";
 export { ProviderRouter } from "./router.js";
 export { McpSamplingAdapter } from "./sampling.js";
+export type { SamplingHost } from "./sampling.js";
 export type { ProviderCapability, ProviderPolicyReport } from "./policy.js";
 export { getProviderPolicyReport } from "./policy.js";
 

--- a/packages/providers/src/sampling.ts
+++ b/packages/providers/src/sampling.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
  * Minimal interface for MCP sampling capability.
  * Avoids importing the full MCP SDK Server type.
  */
-interface SamplingHost {
+export interface SamplingHost {
   createMessage(params: {
     messages: { role: string; content: { type: string; text: string } }[];
     systemPrompt?: string;


### PR DESCRIPTION
Exports the SamplingHost interface from @quillby/providers and adds a proper type cast in server.ts to resolve the overloaded createMessage type mismatch that was failing the typecheck step in CI.