### PR TITLE
fix: CI integration tests and docker-smoke

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules
+**/node_modules
 .git
 .gitignore
 .vscode

--- a/apps/mcp-server/tests/integration/http-auth.test.ts
+++ b/apps/mcp-server/tests/integration/http-auth.test.ts
@@ -44,9 +44,11 @@ beforeAll(async () => {
   dbUrl = `file:${path.join(tempDir, "auth.db")}`;
   port = 3100 + Math.floor(Math.random() * 400);
 
+  const secret = "test-secret-do-not-use-in-production-0123456789abc";
   const env = {
     QUILLBY_AUTH_DB_URL: dbUrl,
     BETTER_AUTH_URL: `http://localhost:${port}`,
+    BETTER_AUTH_SECRET: secret,
   };
 
   runOrThrow("pnpm", ["--filter", "@vncsleal/quillby", "db:push"], env);
@@ -72,6 +74,7 @@ beforeAll(async () => {
       PORT: String(port),
       QUILLBY_AUTH_DB_URL: dbUrl,
       BETTER_AUTH_URL: `http://localhost:${port}`,
+      BETTER_AUTH_SECRET: secret,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN pnpm install --filter @vncsleal/quillby... --no-frozen-lockfile --ignore-scr
 FROM deps AS build
 COPY . .
 RUN pnpm --filter @vncsleal/quillby build
+RUN pnpm deploy --filter @vncsleal/quillby --prod --legacy /app/deploy
 
 # ─── App (SPA) build ─────────────────────────────────────────────────────────────────
 FROM base AS build-app
@@ -46,6 +47,7 @@ COPY apps/app ./apps/app
 ARG VITE_QUILLBY_DEPLOYMENT_MODE=self-hosted
 ARG VITE_QUILLBY_API_BASE_URL=/
 RUN pnpm --filter @quillby/app build
+RUN pnpm deploy --filter @quillby/app --prod --legacy /app/deploy-app
 
 FROM node:22-alpine AS runtime
 WORKDIR /app
@@ -56,11 +58,9 @@ ENV QUILLBY_HTTP_HOST=0.0.0.0
 ENV QUILLBY_AUTH_DB_URL=file:/data/quillby-auth.db
 ENV QUILLBY_DEPLOYMENT_MODE=self-hosted
 
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=build /app/apps/mcp-server/package.json ./package.json
-COPY --from=build /app/apps/mcp-server/bin ./bin
-COPY --from=build /app/apps/mcp-server/dist ./dist
-COPY --from=build-app /app/apps/app/dist ./public/app
+COPY --from=build /app/deploy ./
+COPY --from=build-app /app/deploy-app ./public/app
+RUN apk add --no-cache wget
 
 VOLUME ["/data"]
 EXPOSE 3000
@@ -68,4 +68,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -q --spider http://localhost:3000/health || exit 1
 
-CMD ["node", "dist/mcp/server.js"]
+CMD ["node", "apps/mcp-server/dist/mcp/server.js"]

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -56,6 +56,7 @@ ENV QUILLBY_HTTP_HOST=0.0.0.0
 ENV QUILLBY_AUTH_DB_URL=file:/data/quillby-auth.db
 ENV QUILLBY_DEPLOYMENT_MODE=self-hosted
 
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/apps/mcp-server/package.json ./package.json
 COPY --from=build /app/apps/mcp-server/bin ./bin
 COPY --from=build /app/apps/mcp-server/dist ./dist

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -68,4 +68,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -q --spider http://localhost:3000/health || exit 1
 
-CMD ["node", "apps/mcp-server/dist/mcp/server.js"]
+CMD ["node", "dist/mcp/server.js"]

--- a/packages/database/src/db/migration-schema.ts
+++ b/packages/database/src/db/migration-schema.ts
@@ -1,4 +1,9 @@
 import {
+  user,
+  session,
+  account,
+  verification,
+  apikey,
   hostedUserState,
   hostedWorkspace,
   hostedWorkspaceContext,
@@ -16,6 +21,11 @@ import {
 } from "./schema.js";
 
 export {
+  user,
+  session,
+  account,
+  verification,
+  apikey,
   hostedUserState,
   hostedWorkspace,
   hostedWorkspaceContext,

--- a/tooling/scripts/manage-keys.ts
+++ b/tooling/scripts/manage-keys.ts
@@ -23,8 +23,8 @@
 
 import "dotenv/config";
 import { AuthApi, parseRateLimit, listApiKeysFromDb, deleteApiKeyFromDb } from "@quillby/auth";
-import { auth } from "../src/auth.js";
-import { db, apikey as apikeyTable } from "../src/db.js";
+import { auth } from "../../apps/mcp-server/src/auth.js";
+import { db, apikey as apikeyTable } from "../../apps/mcp-server/src/db.js";
 
 const authApi = new AuthApi(auth);
 


### PR DESCRIPTION
- Add Better Auth tables (user, session, account, verification, apikey) to drizzle migration-schema.ts so db:push creates the full schema on fresh databases
- Fix .dockerignore from 'node_modules' to '**/node_modules' to exclude nested node_modules from Docker build context
- Fix broken relative imports in tooling/scripts/manage-keys.ts